### PR TITLE
feat: add tests and utility functions for parcelles management

### DIFF
--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -1,4 +1,35 @@
 
+## [v2.13.0] — 2026-04-11
+
+### 🚀 Nouveautés
+- Ajoute l'aide contextuelle par mot-clé : `/help parcelle`, `/help semis`, `/help godet`, `/help recolte`, `/help stock`, `/help stats` (US_Aide_contextuelle_par_commande)
+- Enrichit `/help` sans argument d'une section "Aide ciblée" listant les thèmes disponibles ; mot-clé inconnu → liste des mots-clés valides (US_Aide_contextuelle_par_commande)
+- Ajoute `/parcelle modifier [nom] clé=valeur...` pour mettre à jour exposition, superficie ou ordre d'une parcelle existante (US_Plan_occupation_parcelles)
+- Ajoute `/parcelle lister` et son alias `/parcelles` pour lister toutes les parcelles (US_Plan_occupation_parcelles)
+- Enrichit `/parcelle ajouter` pour accepter `[exposition]` et `[superficie]` en paramètres positionnels (US_Plan_occupation_parcelles)
+
+### 🔧 Améliorations techniques
+- Ajoute `update_parcelle` dans `utils/parcelles.py` avec validation des champs via `_CHAMPS_MODIFIER`, lève `LookupError` si parcelle introuvable et `ValueError` si paramètre inconnu
+- Ajoute les constantes statiques `_HELP_PARCELLE`, `_HELP_SEMIS`, `_HELP_GODET`, `_HELP_RECOLTE`, `_HELP_STOCK`, `_HELP_STATS`, `_HELP_CONTEXTUEL` dans `bot.py`
+- Transmet `exposition` et `superficie_m2` depuis le handler `parcelle_confirm` lors de la confirmation de création
+
+## [v2.12.0] — 2026-04-11
+
+### 🚀 Nouveautés
+- Ajoute `/plan` : vue globale du potager par parcelle avec cultures actives, âge J+ de chaque culture et alertes ⚠️ récolte imminente (végétatif ≥ 45 j, reproducteur ≥ 90 j) (US_Plan_occupation_parcelles #18)
+- Ajoute `/plan [nom]` : vue détaillée d'une parcelle spécifique, insensible à la casse
+- Ajoute `/parcelle ajouter [nom]` : création de parcelle avec refus sur doublon exact et demande de confirmation si variante proche (distance Levenshtein ≤ 2)
+- Signale les parcelles libres avec 🟢 et regroupe les cultures sans parcelle dans "Non localisé"
+- Reconnaît les commandes vocales "plan du potager" et "plan parcelle [nom]" et les route vers `/plan`
+
+### 🔧 Améliorations techniques
+- Ajoute `utils/parcelles.py` : `normalize_parcelle_name`, `levenshtein_distance`, `find_doublon`, `create_parcelle`, `get_all_parcelles`, `calcul_occupation_parcelles`
+- Ajoute `cmd_plan`, `cmd_parcelle`, `_extract_plan_parcelle()` et les handlers `/plan` et `/parcelle` dans `bot.py`
+
+### 💾 Base de données
+- Ajoute le modèle SQLAlchemy `Parcelle` dans `database/models.py` (colonne `nom_normalise` UNIQUE)
+- Ajoute `migration_v10.sql` : création de la table `parcelles` avec prépopulation depuis `evenements`
+
 ## [v2.11.0] — 2026-04-09
 
 ### 🚀 Nouveautés

--- a/backlog/BUG_Correction_variete_absente_recherche_et_affichage
+++ b/backlog/BUG_Correction_variete_absente_recherche_et_affichage
@@ -1,0 +1,77 @@
+**Titre :** Variété absente du critère de recherche et de l'affichage dans le mode correction
+
+**Type :** Bug
+
+**Priorité :** Haute
+
+**Story :**
+En tant que jardinier
+Je veux pouvoir retrouver un événement en précisant sa variété (ex : "modifier plantation tomate ronde")
+Et voir la variété affichée dans la liste de sélection
+Afin de distinguer sans ambiguïté deux enregistrements de la même culture quand ils diffèrent par la variété
+
+**Contexte et trace observée :**
+💬 MESSAGE TEXTE : modifier plantation tomate ronde
+🔎 CRITÈRES RECHERCHE : {'action': 'plantation', 'culture': 'tomate', 'date_debut': None, 'date_fin': None, 'parcelle': None}
+🔎 RÉSULTATS SQL : 2 trouvé(s)
+
+Plusieurs événements trouvés, lequel voulez-vous modifier ?
+
+#247 07/04 — plantation tomate 10.0plants
+#162 12/02 — plantation tomate 30.0plants [sud]
+La variété "ronde" n'a pas été transmise au filtre SQL, et les lignes affichées ne l'incluent pas.
+
+**Cause identifiée (deux bugs distincts) :**
+
+**Bug 1 — `_find_candidates` dans `bot.py` : variété absente du schéma Groq et du filtre SQL**
+Le prompt envoyé à Groq ne demande que `{action, culture, date_debut, date_fin, parcelle}`.
+Le champ `variete` n'est ni extrait ni utilisé pour filtrer `Evenement.variete` en SQL.
+
+**Bug 2 — `_fmt_event` dans `bot.py` : variété absente du formatage**
+```python
+def _fmt_event(e) -> str:
+    cult = f" {e.culture}" if e.culture else ""
+    # ← e.variete absent → "tomate" au lieu de "tomate (ronde)"
+Critères d'acceptance :
+
+ CA1 : Quand l'utilisateur tape "modifier plantation tomate ronde", le log CRITÈRES RECHERCHE contient 'variete': 'ronde'
+ CA2 : La requête SQL filtre sur Evenement.variete.ilike("%ronde%") si la variété est renseignée dans les critères
+ CA3 : Le filtre variété est optionnel (null si non mentionné) — la recherche sans variété doit continuer à fonctionner
+ CA4 : _fmt_event affiche la variété entre parenthèses quand elle est non nulle : #247 07/04 — plantation tomate (ronde) 10.0plants
+ CA5 : La liste de sélection multi-résultats affiche la variété, permettant de distinguer deux enregistrements d'une même culture  
+ bot.py — fonction _find_candidates : prompt Groq + filtre SQL
+bot.py — fonction _fmt_event : mise en forme d'un événement
+Migration BDD requise : non
+
+Estimation : 1 point
+
+Scénario Gherkin :
+
+Feature: Recherche par variété dans le mode correction
+
+  Scenario: Variété incluse dans les critères de recherche
+    Given le jardinier est en mode correction
+    When il tape "modifier plantation tomate ronde"
+    Then les critères extraits contiennent action="plantation", culture="tomate", variete="ronde"
+    And la requête SQL filtre sur variete ILIKE "%ronde%"
+    And seuls les événements de la variété "ronde" sont retournés
+
+  Scenario: Variété affichée dans la liste multi-résultats
+    Given 2 événements de type "plantation tomate" existent en base avec des variétés différentes
+    When le bot présente la liste de sélection
+    Then chaque ligne affiche la variété entre parenthèses
+    And l'utilisateur peut distinguer les deux enregistrements
+
+  Scenario: Recherche sans variété (rétrocompatibilité)
+    When le jardinier tape "modifier plantation tomate"
+    Then les critères extraits contiennent variete=null
+    And la requête SQL ne filtre pas sur la variété
+    And tous les événements de plantation tomate sont retournés
+
+  Scenario: Événement sans variété affiché sans parenthèses
+    Given un événement tomate sans variété renseignée
+    When _fmt_event est appelé
+    Then la ligne affichée est "#X DD/MM — plantation tomate 10.0plants"
+    And aucun "()" vide n'apparaît
+
+    Labels GitHub : bug, correction, sprint-courant, bot, ux

--- a/backlog/US_Aide_contextuelle_par_commande.md
+++ b/backlog/US_Aide_contextuelle_par_commande.md
@@ -1,0 +1,244 @@
+**Titre :** Fournir une aide contextuelle ciblée via /help [commande]
+
+**Story :**
+En tant que jardinier
+Je veux saisir `/help parcelle` (ou `/help semis`, `/help recolte`, etc.) pour obtenir une aide détaillée sur cette seule commande
+Afin de comprendre rapidement toutes les options et usages possibles sans lire l'aide générale complète
+
+**Critères d'acceptance :**
+- [x] CA1 : La commande `/help <mot-clé>` retourne un message dédié au domaine ou à la commande demandée (ex : `/help parcelle`, `/help semis`, `/help stock`, `/help recolte`, `/help stats`)
+- [x] CA2 : Le message contextuel liste toutes les variantes de saisie reconnues pour ce domaine (options, mots-clés alternatifs)
+- [x] CA3 : Chaque variante est accompagnée d'au moins 1 exemple concret de message vocal ou texte à envoyer au bot
+- [x] CA4 : Si le mot-clé n'est pas reconnu, le bot répond avec la liste des mots-clés d'aide disponibles (ex : `Mots-clés disponibles : parcelle, semis, recolte, stock, stats, godet`)
+- [x] CA5 : La commande `/help` sans argument continue d'afficher l'aide générale existante (rétrocompatibilité)
+- [x] CA6 : Chaque message d'aide contextuelle reste ≤ 4096 chars et lisible sur écran mobile
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : interaction Telegram (bot.py, handler `/help`)
+- Migration BDD requise : non
+- Dépendances : US_Restructurer_help_4_domaines (à livrer après, ou en parallèle si la structure générale est stable)
+- Contenu 100% statique, zéro token Groq
+- Mots-clés d'aide à couvrir en priorité : `parcelle`, `semis`, `recolte`, `stock`, `stats`, `godet`
+- Le parsing du mot-clé est insensible à la casse et aux accents (`Récolte` = `recolte`)
+
+**Estimation :** 3 points
+
+**Scénario Gherkin :**
+```gherkin
+Feature: /help contextuel par commande
+
+  Scenario: Aide détaillée sur les parcelles
+    Given le bot est démarré
+    When le jardinier envoie "/help parcelle"
+    Then le bot répond avec un message dédié aux parcelles
+    And le message liste toutes les options reconnues (créer, lister, affecter, libérer…)
+    And chaque option est illustrée par au moins 1 exemple de saisie
+
+  Scenario: Aide détaillée sur les semis
+    When le jardinier envoie "/help semis"
+    Then le bot répond avec un message dédié aux semis
+    And le message distingue semis pépinière et pleine terre
+    And fournit des exemples vocaux concrets
+
+  Scenario: Mot-clé inconnu
+    When le jardinier envoie "/help truc"
+    Then le bot répond "Mot-clé non reconnu."
+    And liste les mots-clés d'aide disponibles
+
+  Scenario: Aide générale inchangée
+    When le jardinier envoie "/help"
+    Then le bot affiche l'aide générale complète (comportement existant)
+```
+
+**Labels GitHub :** `us`, `sprint-next`, `bot`, `ux`, `help`, `priorite-haute`
+
+---
+
+## Maquettes des messages affichés
+
+> Ces maquettes définissent le contenu attendu de chaque réponse contextuelle. Le développeur doit les reproduire à l'identique (emojis, structure, exemples).
+
+---
+
+### `/help parcelle`
+
+```
+📍 Aide — Parcelles
+
+Gérer et consulter vos parcelles du potager.
+
+── Plan d'occupation ──────────────────────────
+• Vue globale de toutes les parcelles
+  → /plan
+  → "plan du potager"
+
+• Vue détaillée d'une parcelle
+  → /plan nord
+  → "plan parcelle nord"
+  → "qu'est-ce qui pousse en nord ?"
+
+── Gestion des parcelles ──────────────────────
+• Lister toutes les parcelles connues
+  → /parcelle lister
+  → /parcelles
+
+• Créer une nouvelle parcelle
+  → /parcelle ajouter nord
+  → /parcelle ajouter nord sud 12.5
+    (nom · exposition · superficie en m²)
+
+• Modifier les métadonnées d'une parcelle
+  → /parcelle modifier nord exposition=sud
+  → /parcelle modifier nord superficie=8.5
+  → /parcelle modifier nord exposition=sud superficie=8.5
+  Paramètres : exposition · superficie · ordre
+
+💡 Noms de parcelle insensibles à la casse.
+   Les doublons sont détectés automatiquement.
+```
+
+---
+
+### `/help semis`
+
+```
+🌱 Aide — Semis
+
+Enregistrer vos semis en pépinière ou en pleine terre.
+
+Actions disponibles :
+• Semis en pépinière
+  → "semis tomates variété Saint-Pierre le 5 mars"
+  → "j'ai semé 30 graines de basilic en plateau"
+
+• Semis en pleine terre
+  → "semis direct carottes en parcelle B2"
+  → "semis radis pleine terre parcelle A3 le 8 avril"
+
+• Consulter les semis en cours
+  → "liste de mes semis"
+  → "quels semis sont en cours ?"
+
+💡 Précisez toujours : culture · variété (optionnel) · date · lieu
+```
+
+---
+
+### `/help godet`
+
+```
+🪴 Aide — Mise en godet
+
+Suivre le repiquage des plants de pépinière en godet.
+
+Actions disponibles :
+• Enregistrer une mise en godet
+  → "mise en godet tomates Saint-Pierre 20 plants"
+  → "repiquer 15 plants de poivron en godet le 10 mars"
+
+• Consulter les godets en attente
+  → "liste des godets"
+  → "quels plants sont en godet ?"
+
+💡 La mise en godet est l'étape entre le semis plateau
+   et la plantation en parcelle.
+```
+
+---
+
+### `/help recolte`
+
+```
+🧺 Aide — Récoltes
+
+Enregistrer vos récoltes ponctuelles ou finales.
+
+Actions disponibles :
+• Récolte ponctuelle (culture continue)
+  → "récolté 800g de tomates en A1"
+  → "cueilli 3 courgettes parcelle B2 aujourd'hui"
+
+• Récolte finale / clôture de culture
+  → "récolte finale haricots parcelle A3"
+  → "dernière récolte courgettes B2, culture terminée"
+
+• Récolte de graines
+  → "récolte graines tomates Saint-Pierre 15g"
+  → "mis de côté graines courge pour semis prochain"
+
+• Consulter l'historique
+  → "historique récoltes"
+  → "mes récoltes du mois de mars"
+```
+
+---
+
+### `/help stock`
+
+```
+📦 Aide — Stock
+
+Suivre vos stocks de semences et intrants.
+
+Actions disponibles :
+• Consulter le stock
+  → "stock tomates"
+  → "combien de graines de basilic il me reste ?"
+
+• Ajouter au stock
+  → "ajout stock carottes Nantaise 50g"
+  → "reçu 1 sachet poivron Corno di Toro"
+
+• Déduire du stock (automatique après semis)
+  → Le stock est mis à jour automatiquement
+    à chaque semis enregistré.
+
+• Alertes stock faible
+  → Le bot signale automatiquement si un stock
+    passe sous le seuil critique.
+```
+
+---
+
+### `/help stats`
+
+```
+📊 Aide — Statistiques
+
+Consulter les bilans de votre potager.
+
+Actions disponibles :
+• Statistiques générales
+  → "/stats"
+  → "bilan du potager"
+
+• Stats par culture
+  → "stats tomates"
+  → "bilan courgettes cette saison"
+
+• Stats par parcelle
+  → "stats parcelle A1"
+  → "bilan rotation parcelle B2"
+
+• Synthèse des semis
+  → "synthèse semis"
+  → "récapitulatif de mes semis"
+
+• Bilan de rotation
+  → "rotation des cultures"
+  → "quelles familles ont occupé chaque parcelle ?"
+```
+
+---
+
+### Mot-clé inconnu — `/help truc`
+
+```
+❓ Mot-clé "truc" non reconnu.
+
+Mots-clés disponibles :
+  parcelle · semis · godet · recolte · stock · stats
+
+Exemple : /help parcelle
+```
+

--- a/backlog/US_Plan_occupation_parcelles.md
+++ b/backlog/US_Plan_occupation_parcelles.md
@@ -1,0 +1,357 @@
+**Titre :** Afficher le plan d'occupation actuel du potager par parcelle
+
+**Référence GitHub :** issue #18 — [FEATURE] Multi-parcelles — table parcelles + commande /plan
+
+**Story :**
+En tant que jardinier
+Je veux consulter le plan d'occupation actuel de mon potager parcelle par parcelle
+Afin de savoir en un coup d'œil ce qui pousse où, l'âge de mes plants et les parcelles libres disponibles pour mes prochains semis
+
+**Critères d'acceptance :**
+- [ ] CA1 : `/plan` retourne un message structuré par parcelle listant les cultures actives avec leur variété et leur nombre de plants
+- [ ] CA2 : Chaque culture affiche son **âge en jours** (J+ depuis la première plantation sur cette parcelle/culture)
+- [ ] CA3 : Les cultures dont l'âge dépasse un seuil typique pour leur type (végétatif ≥ 45 j, reproducteur ≥ 90 j) sont marquées `⚠️ récolte imminente`
+- [ ] CA4 : Les parcelles sans culture active sont affichées comme `🟢 [NOM] — Libre`
+- [ ] CA5 : `/plan nord` filtre l'affichage sur la parcelle "nord" (insensible à la casse)
+- [ ] CA6 : Le pied du message contient le hint `_Pour le détail d'une parcelle : /plan [nom]_` et un renvoi vers la commande d'analyse de rotation
+- [ ] CA7 : Les cultures sans parcelle renseignée sont regroupées sous `📍 Non localisé`
+- [ ] CA8 : La table `parcelles` est créée en BDD pour stocker les métadonnées de chaque parcelle (nom, exposition, superficie, ordre d'affichage)
+- [ ] CA9 : La commande vocale "plan du potager" ou "plan parcelle nord" est reconnue et redirigée vers `/plan`
+- [ ] CA10 : Lors de l'ajout d'une parcelle, un contrôle de doublon est effectué : si un nom identique ou une variante proche existe déjà (ex : "Nord" / "NORD" / "nord"), le bot refuse la création et affiche `❌ La parcelle "NORD" existe déjà`
+- [ ] CA11 : La détection de variante s'appuie sur une normalisation (strip + lower + suppression des accents et tirets) avant comparaison ; "Serre-froide" et "Serre Froide" sont considérés comme identiques
+- [ ] CA12 : En cas de variante proche détectée sans correspondance exacte, le bot propose : `⚠️ Une parcelle similaire existe : "Serre Froide". Confirmer la création de "Serre-froide" ? (oui / non)`
+- [ ] CA13 : La commande `/parcelle ajouter [nom]` permet de créer une nouvelle parcelle ; un récapitulatif de toutes les parcelles existantes est affiché avant de demander confirmation
+
+**Exemples d'affichage attendus :**
+
+`/plan` (vue globale) :
+```
+📋 Plan d'occupation — 11 avr 2026
+
+📍 NORD · 3 cultures actives
+  🍅 Tomate Cœur de Bœuf — 3 plants · J+27
+  🥬 Salade Batavia — 8 plants · J+32 ⚠️ récolte imminente
+  🥕 Carotte Nantaise — 50 graines · J+15
+
+📍 SUD · 2 cultures actives
+  🌿 Courgette — 2 plants · J+18
+  🫑 Poivron — 4 plants · J+12
+
+🟢 EST — Libre
+🟢 SERRE — Libre
+
+📍 Non localisé · 1 culture
+  🌱 Basilic — 20 plants · J+8
+
+_Pour le détail : /plan [nom parcelle]_
+_Historique de rotation : "rotation parcelle nord"_
+```
+
+`/plan nord` (vue parcelle) :
+```
+📍 NORD — Plan détaillé
+
+🍅 Tomate Cœur de Bœuf
+  3 plants actifs · plantés le 15 mars (J+27)
+  Type : reproducteur · Rendement en cours : 0 kg
+
+🥬 Salade Batavia
+  8 plants · plantés le 10 mars (J+32)
+  ⚠️ Récolte imminente (végétatif > 45 j)
+
+🥕 Carotte Nantaise
+  50 graines · semées le 27 mars (J+15)
+
+_Historique de rotation : "rotation parcelle nord"_
+```
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle : consultation / dashboard / parcelles
+- Migration BDD requise : **oui** — création table `parcelles` (id, nom, nom_normalise, exposition, superficie_m2, ordre, actif) ; `nom_normalise` (String unique) stocke la forme canonique (lower + sans accents + sans tirets/espaces) pour garantir l'unicité en BDD
+- Le champ `parcelle` (String) sur `Evenement` reste la source de données principale ; la table `parcelles` sert uniquement aux métadonnées d'affichage (ordre, libellé, exposition)
+- Normalisation : `strip().lower().replace("-", "").replace(" ", "")` + suppression des accents (ex : "Sère-Froide" → "serefroi­de") — fonction partagée `normalize_parcelle_name()` dans `utils/`
+- Contrôle doublon : 1) comparaison exacte sur `nom_normalise` → refus immédiat ; 2) distance de Levenshtein ≤ 2 sur `nom_normalise` → confirmation demandée (CA12)
+- Calcul âge : `date_today - MIN(Evenement.date WHERE type_action='plantation' AND culture=X AND parcelle=P)`
+- Cultures "actives" = cultures ayant des plants en stock positif (réutilise `calcul_stock_cultures` de `utils/stock.py`)
+- Seuil d'alerte configurable : végétatif ≥ 45 j, reproducteur ≥ 90 j (valeur par défaut, extensible via `culture_config`)
+- Pas de table pivot : la jointure se fait par correspondance de la valeur `parcelle` (String) entre `Evenement` et `parcelles`
+- Fichiers impactés : `migrations/migration_vX.sql`, `database/models.py`, `bot.py`, `utils/parcelles.py` (nouveau — normalisation + CRUD), `utils/stock.py` (optionnel)
+- Dépendances : US_Bilan_rotation_par_parcelle (complémentaire — historique), US-002 `calcul_stock_cultures`
+
+**Estimation :** 5 points
+
+**Scénario Gherkin :**
+```gherkin
+Feature: Plan d'occupation du potager par parcelle
+
+  Scenario: Vue globale /plan
+    Given des plantations actives sur les parcelles NORD et SUD
+    And la parcelle EST n'a aucune culture active
+    When l'utilisateur envoie /plan
+    Then le message contient une section "📍 NORD" avec les cultures actives
+    And le message contient une section "📍 SUD" avec ses cultures
+    And le message contient "🟢 EST — Libre"
+    And le pied contient le hint de navigation
+
+  Scenario: Affichage de l'âge des plants
+    Given 3 plants de Tomate Cœur de Bœuf plantés il y a 27 jours sur NORD
+    When l'utilisateur envoie /plan
+    Then la ligne contient "J+27"
+
+  Scenario: Alerte récolte imminente végétatif
+    Given 8 plants de Salade Batavia plantés il y a 46 jours sur NORD
+    And salade est classifiée type_organe_recolte = "végétatif"
+    When l'utilisateur envoie /plan
+    Then la ligne contient "⚠️ récolte imminente"
+
+  Scenario: Pas d'alerte pour reproducteur avant 90 jours
+    Given 3 plants de Tomate plantés il y a 27 jours
+    And tomate est classifiée type_organe_recolte = "reproducteur"
+    When l'utilisateur envoie /plan
+    Then la ligne ne contient pas "⚠️"
+
+  Scenario: Vue parcelle spécifique /plan nord
+    Given des cultures sur NORD et sur SUD
+    When l'utilisateur envoie /plan nord
+    Then le message contient uniquement les cultures de la parcelle NORD
+    And le message ne contient pas les cultures de SUD
+
+  Scenario: Parcelle inconnue
+    Given aucune culture sur la parcelle "OUEST"
+    When l'utilisateur envoie /plan ouest
+    Then le bot répond "Aucune culture active sur la parcelle OUEST"
+
+  Scenario: Cultures sans parcelle
+    Given une culture Basilic sans parcelle renseignée
+    When l'utilisateur envoie /plan
+    Then la section "📍 Non localisé" contient Basilic
+
+  Scenario: Commande vocale
+    Given le jardinier dicte "plan du potager"
+    When le bot reçoit le message vocal transcrit
+    Then le bot produit le même affichage que /plan
+
+  Scenario: Création d'une parcelle sans doublon
+    Given aucune parcelle "NORD" n'existe en base
+    When l'utilisateur envoie /parcelle ajouter nord
+    Then le bot affiche la liste des parcelles existantes
+    And demande confirmation avant création
+    And crée la parcelle avec nom_normalise = "nord"
+
+  Scenario: Refus de doublon exact
+    Given la parcelle "NORD" (nom_normalise="nord") existe déjà en base
+    When l'utilisateur envoie /parcelle ajouter NORD
+    Then le bot répond "❌ La parcelle "NORD" existe déjà"
+    And aucune nouvelle ligne n'est insérée en base
+
+  Scenario: Détection de variante proche et demande de confirmation
+    Given la parcelle "Serre Froide" (nom_normalise="serrefroide") existe déjà
+    When l'utilisateur envoie /parcelle ajouter Serre-froide
+    Then le bot répond "⚠️ Une parcelle similaire existe : "Serre Froide". Confirmer la création ? (oui / non)"
+    And si l'utilisateur répond "non" aucune parcelle n'est créée
+    And si l'utilisateur répond "oui" la parcelle "Serre-froide" est créée avec son propre nom_normalise
+```
+
+---
+
+## Référentiel des commandes — détail complet
+
+> Pour chaque commande : syntaxe exacte, paramètres acceptés, comportement attendu et exemple de réponse du bot.
+
+---
+
+### `/plan` — Vue globale
+
+**Syntaxe :** `/plan`  
+**Commande vocale équivalente :** "plan du potager"
+
+Affiche toutes les parcelles avec leurs cultures actives, l'âge des plants et les parcelles libres.
+
+**Exemple de réponse :**
+```
+📋 Plan d'occupation — 11 avr 2026
+
+📍 NORD · 3 cultures actives
+  🍅 Tomate Cœur de Bœuf — 3 plants · J+27
+  🥬 Salade Batavia — 8 plants · J+32 ⚠️ récolte imminente
+  🥕 Carotte Nantaise — 50 graines · J+15
+
+📍 SUD · 2 cultures actives
+  🌿 Courgette — 2 plants · J+18
+  🫑 Poivron — 4 plants · J+12
+
+🟢 EST — Libre
+🟢 SERRE — Libre
+
+📍 Non localisé · 1 culture
+  🌱 Basilic — 20 plants · J+8
+
+_Pour le détail : /plan [nom parcelle]_
+_Historique de rotation : "rotation parcelle nord"_
+```
+
+---
+
+### `/plan [nom]` — Vue détaillée d'une parcelle
+
+**Syntaxe :** `/plan nord`  
+**Commande vocale équivalente :** "plan parcelle nord", "qu'est-ce qui pousse en nord ?"  
+**Paramètres :**
+
+| Paramètre | Obligatoire | Description |
+|-----------|-------------|-------------|
+| `nom` | oui | Nom de la parcelle (insensible à la casse) |
+
+**Exemple de réponse :**
+```
+📍 NORD — Plan détaillé
+
+🍅 Tomate Cœur de Bœuf
+  3 plants actifs · plantés le 15 mars (J+27)
+  Type : reproducteur · Rendement en cours : 0 kg
+
+🥬 Salade Batavia
+  8 plants · plantés le 10 mars (J+32)
+  ⚠️ Récolte imminente (végétatif > 45 j)
+
+🥕 Carotte Nantaise
+  50 graines · semées le 27 mars (J+15)
+
+_Historique de rotation : "rotation parcelle nord"_
+```
+
+**Cas d'erreur :**
+```
+❌ Aucune culture active sur la parcelle OUEST.
+Parcelles connues : nord, sud, est, serre
+```
+
+---
+
+### `/parcelle ajouter` — Créer une nouvelle parcelle
+
+**Syntaxe complète :** `/parcelle ajouter [nom] [exposition] [superficie]`  
+**Commande vocale équivalente :** "ajouter une nouvelle parcelle nord"
+
+**Paramètres :**
+
+| Paramètre | Obligatoire | Type | Description |
+|-----------|-------------|------|-------------|
+| `nom` | oui | texte | Nom unique de la parcelle (ex : `nord`, `serre-froide`) |
+| `exposition` | non | texte | Orientation cardinale ou descriptive (ex : `sud`, `mi-ombre`) |
+| `superficie` | non | décimal (m²) | Surface en m² (ex : `12.5`) |
+
+**Exemples d'utilisation :**
+```
+/parcelle ajouter nord
+/parcelle ajouter nord sud 12.5
+/parcelle ajouter serre-froide mi-ombre 6
+```
+
+**Flux complet (création sans doublon) :**
+```
+Jardinier : /parcelle ajouter nord sud 12.5
+
+Bot :
+📋 Parcelles existantes :
+  · SUD · 8 m²
+  · EST · 6 m²
+  · SERRE · 15 m²
+
+➕ Créer la parcelle "NORD" (exposition : sud · superficie : 12.5 m²) ?
+Répondez oui pour confirmer.
+
+Jardinier : oui
+
+Bot : ✅ Parcelle "NORD" créée avec succès.
+```
+
+**Cas d'erreur — doublon exact :**
+```
+Jardinier : /parcelle ajouter NORD
+
+Bot : ❌ La parcelle "NORD" existe déjà.
+Utilisez /plan pour consulter les parcelles existantes.
+```
+
+**Cas d'erreur — variante proche (Levenshtein ≤ 2) :**
+```
+Jardinier : /parcelle ajouter Serre-froide
+
+Bot : ⚠️ Une parcelle similaire existe : "Serre Froide".
+Confirmer la création de "Serre-froide" quand même ? (oui / non)
+
+Jardinier : non
+Bot : ↩️ Création annulée.
+```
+
+---
+
+### `/parcelle modifier` — Mettre à jour les métadonnées
+
+**Syntaxe complète :** `/parcelle modifier [nom] [clé=valeur ...]`  
+**Commande vocale équivalente :** *(non supportée pour cette commande — saisie texte uniquement)*
+
+**Paramètres :**
+
+| Paramètre | Obligatoire | Type | Valeurs acceptées |
+|-----------|-------------|------|-------------------|
+| `nom` | oui | texte | Nom de la parcelle existante (insensible à la casse) |
+| `exposition=` | non | texte | `nord`, `sud`, `est`, `ouest`, `mi-ombre`, `ombre`, `plein-soleil` |
+| `superficie=` | non | décimal | Surface en m² (ex : `8.5`) |
+| `ordre=` | non | entier | Position d'affichage dans `/plan` (ex : `1`) |
+
+**Exemples d'utilisation :**
+```
+/parcelle modifier nord exposition=sud
+/parcelle modifier nord superficie=8.5
+/parcelle modifier nord exposition=sud superficie=8.5
+/parcelle modifier serre-froide ordre=1 superficie=15
+```
+
+**Exemple de réponse (succès) :**
+```
+Jardinier : /parcelle modifier nord exposition=sud superficie=8.5
+
+Bot : ✅ Parcelle "NORD" mise à jour :
+  · Exposition : sud
+  · Superficie : 8.5 m²
+```
+
+**Cas d'erreur — parcelle introuvable :**
+```
+Bot : ❌ Parcelle "OUEST" introuvable.
+Parcelles connues : nord, sud, est, serre
+```
+
+**Cas d'erreur — paramètre inconnu :**
+```
+Jardinier : /parcelle modifier nord couleur=verte
+
+Bot : ❌ Paramètre inconnu : "couleur".
+Paramètres acceptés : exposition, superficie, ordre
+```
+
+---
+
+### `/parcelle lister` — Afficher toutes les parcelles
+
+**Syntaxe :** `/parcelle lister`  
+**Alias :** `/parcelles`
+
+**Exemple de réponse :**
+```
+📋 Parcelles enregistrées (4)
+
+📍 NORD · exposition sud · 12.5 m²
+📍 SUD · exposition nord · 8 m²
+📍 EST · exposition est · 6 m²
+🟢 SERRE · exposition mixte · 15 m² — aucune culture active
+
+_Ajouter : /parcelle ajouter [nom] [exposition] [superficie]_
+_Modifier : /parcelle modifier [nom] clé=valeur_
+```
+
+---
+
+**Labels GitHub :** `us`, `feature`, `données`, `parcelle`, `dashboard`, `telegram-ux`, `deduplication`

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 bot.py — Bot Telegram pour l'Assistant Potager
 ------------------------------------------------
 Fonctionnalités :
@@ -52,6 +52,11 @@ from config import GROQ_API_KEY, DATABASE_URL, TELEGRAM_BOT_TOKEN, GROQ_WHISPER_
 from database.db import SessionLocal, Base, engine
 from database.models import Evenement
 from utils.actions import normalize_action
+from utils.parcelles import (
+    calcul_occupation_parcelles, normalize_parcelle_name,
+    find_doublon, create_parcelle, update_parcelle, get_all_parcelles,
+    resolve_parcelle,
+)
 from llm.groq_client import parse_commande, repondre_question
 from utils.ia_orchestrator import build_question_context
 from utils.date_utils import parse_date
@@ -278,8 +283,167 @@ async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     )
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Aide_contextuelle_par_commande] Textes d'aide contextuels par mot-clé
+# ──────────────────────────────────────────────────────────────────────────────
+
+_HELP_PARCELLE = (
+    "📍 *Aide — Parcelles*\n"
+    "Gérer et consulter vos parcelles du potager.\n\n"
+    "*── Plan d'occupation ──*\n"
+    "• Vue globale de toutes les parcelles\n"
+    "  → /plan\n"
+    "  → _\"plan du potager\"_\n"
+    "• Vue détaillée d'une parcelle\n"
+    "  → /plan nord\n"
+    "  → _\"plan parcelle nord\"_\n"
+    "  → _\"qu'est-ce qui pousse en nord ?\"_\n\n"
+    "*── Gestion des parcelles ──*\n"
+    "• Lister toutes les parcelles connues\n"
+    "  → /parcelle lister\n"
+    "  → /parcelles\n"
+    "• Créer une nouvelle parcelle\n"
+    "  → /parcelle ajouter nord\n"
+    "  → /parcelle ajouter nord sud 12.5\n"
+    "  _(nom · exposition · superficie en m²)_\n"
+    "• Modifier les métadonnées d'une parcelle\n"
+    "  → /parcelle modifier nord exposition=sud\n"
+    "  → /parcelle modifier nord superficie=8.5\n"
+    "  → /parcelle modifier nord exposition=sud superficie=8.5\n"
+    "  _Paramètres : exposition · superficie · ordre_\n\n"
+    "💡 _Noms de parcelle insensibles à la casse.\n"
+    "   Les doublons sont détectés automatiquement._"
+)
+
+_HELP_SEMIS = (
+    "🌱 *Aide — Semis*\n"
+    "Enregistrer vos semis en pépinière ou en pleine terre.\n\n"
+    "*Actions disponibles :*\n"
+    "• Semis en pépinière\n"
+    "  → _\"semis tomates variété Saint-Pierre le 5 mars\"_\n"
+    "  → _\"j'ai semé 30 graines de basilic en plateau\"_\n"
+    "• Semis en pleine terre\n"
+    "  → _\"semis direct carottes en parcelle B2\"_\n"
+    "  → _\"semis radis pleine terre parcelle A3 le 8 avril\"_\n"
+    "• Consulter les semis en cours\n"
+    "  → _\"liste de mes semis\"_\n"
+    "  → _\"quels semis sont en cours ?\"_\n\n"
+    "💡 _Précisez toujours : culture · variété (optionnel) · date · lieu_"
+)
+
+_HELP_GODET = (
+    "🪴 *Aide — Mise en godet*\n"
+    "Suivre le repiquage des plants de pépinière en godet.\n\n"
+    "*Actions disponibles :*\n"
+    "• Enregistrer une mise en godet\n"
+    "  → _\"mise en godet tomates Saint-Pierre 20 plants\"_\n"
+    "  → _\"repiquer 15 plants de poivron en godet le 10 mars\"_\n"
+    "• Consulter les godets en attente\n"
+    "  → _\"liste des godets\"_\n"
+    "  → _\"quels plants sont en godet ?\"_\n\n"
+    "💡 _La mise en godet est l'étape entre le semis plateau\n"
+    "   et la plantation en parcelle._"
+)
+
+_HELP_RECOLTE = (
+    "🧺 *Aide — Récoltes*\n"
+    "Enregistrer vos récoltes ponctuelles ou finales.\n\n"
+    "*Actions disponibles :*\n"
+    "• Récolte ponctuelle (culture continue)\n"
+    "  → _\"récolté 800g de tomates en A1\"_\n"
+    "  → _\"cueilli 3 courgettes parcelle B2 aujourd'hui\"_\n"
+    "• Récolte finale / clôture de culture\n"
+    "  → _\"récolte finale haricots parcelle A3\"_\n"
+    "  → _\"dernière récolte courgettes B2, culture terminée\"_\n"
+    "• Récolte de graines\n"
+    "  → _\"récolte graines tomates Saint-Pierre 15g\"_\n"
+    "  → _\"mis de côté graines courge pour semis prochain\"_\n"
+    "• Consulter l'historique\n"
+    "  → _\"historique récoltes\"_\n"
+    "  → _\"mes récoltes du mois de mars\"_"
+)
+
+_HELP_STOCK = (
+    "📦 *Aide — Stock*\n"
+    "Suivre vos stocks de semences et intrants.\n\n"
+    "*Actions disponibles :*\n"
+    "• Consulter le stock\n"
+    "  → _\"stock tomates\"_\n"
+    "  → _\"combien de graines de basilic il me reste ?\"_\n"
+    "• Ajouter au stock\n"
+    "  → _\"ajout stock carottes Nantaise 50g\"_\n"
+    "  → _\"reçu 1 sachet poivron Corno di Toro\"_\n"
+    "• Déduire du stock (automatique après semis)\n"
+    "  → _Le stock est mis à jour automatiquement_\n"
+    "  → _à chaque semis enregistré._\n"
+    "• Alertes stock faible\n"
+    "  → _Le bot signale automatiquement si un stock_\n"
+    "  → _passe sous le seuil critique._"
+)
+
+_HELP_STATS = (
+    "📊 *Aide — Statistiques*\n"
+    "Consulter les bilans de votre potager.\n\n"
+    "*Actions disponibles :*\n"
+    "• Statistiques générales\n"
+    "  → /stats\n"
+    "  → _\"bilan du potager\"_\n"
+    "• Stats par culture\n"
+    "  → _\"stats tomates\"_\n"
+    "  → _\"bilan courgettes cette saison\"_\n"
+    "• Stats par parcelle\n"
+    "  → _\"stats parcelle A1\"_\n"
+    "  → _\"bilan rotation parcelle B2\"_\n"
+    "• Synthèse des semis\n"
+    "  → _\"synthèse semis\"_\n"
+    "  → _\"récapitulatif de mes semis\"_\n"
+    "• Bilan de rotation\n"
+    "  → _\"rotation des cultures\"_\n"
+    "  → _\"quelles familles ont occupé chaque parcelle ?\"_"
+)
+
+_HELP_MOTS_CLES = "parcelle · semis · godet · recolte · stock · stats"
+
+_HELP_CONTEXTUEL: dict[str, str] = {
+    "parcelle":  _HELP_PARCELLE,
+    "parcelles": _HELP_PARCELLE,
+    "plan":      _HELP_PARCELLE,
+    "semis":     _HELP_SEMIS,
+    "godet":     _HELP_GODET,
+    "godets":    _HELP_GODET,
+    "recolte":   _HELP_RECOLTE,
+    "recoltes":  _HELP_RECOLTE,
+    "stock":     _HELP_STOCK,
+    "stocks":    _HELP_STOCK,
+    "stats":     _HELP_STATS,
+    "statistiques": _HELP_STATS,
+}
+
+
 async def cmd_help(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
-    """Aide en ligne synthétique, optimisée mobile."""
+    """[US_Aide_contextuelle_par_commande] Aide générale ou ciblée via /help [mot-clé]."""
+    from unidecode import unidecode as _uni
+
+    mot_cle = (ctx.args[0].lower().strip() if ctx.args else None)
+    if mot_cle:
+        mot_cle = _uni(mot_cle)  # insensible aux accents
+
+    if mot_cle and mot_cle in _HELP_CONTEXTUEL:
+        await update.message.reply_text(
+            _HELP_CONTEXTUEL[mot_cle], parse_mode="Markdown"
+        )
+        return
+
+    if mot_cle and mot_cle not in _HELP_CONTEXTUEL:
+        await update.message.reply_text(
+            f'❓ Mot-clé \"*{mot_cle}*\" non reconnu.\n\n'
+            f"Mots-clés disponibles :\n  {_HELP_MOTS_CLES}\n\n"
+            f"Exemple : /help parcelle",
+            parse_mode="Markdown",
+        )
+        return
+
+    # ── Aide générale (comportement existant / CA5) ────────────────────────────
     texte = (
         "🌿 *AIDE — Assistant Potager*\n"
         "━━━━━━━━━━━━━━━━━━━━\n\n"
@@ -300,6 +464,8 @@ async def cmd_help(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         "━━━━━━━━━━━━━━━━━━━━\n"
         "*⌨️ Commandes*\n"
         "/start — Menu principal\n"
+        "/plan — Plan d'occupation des parcelles\n"
+        "/parcelle ajouter [nom] — Créer une parcelle\n"
         "/stats — Statistiques saison\n"
         "/historique — 10 derniers événements\n"
         "/ask — Question analytique\n"
@@ -308,10 +474,9 @@ async def cmd_help(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         "/tts\\_on · /tts\\_off — Vocal on/off\n"
         "/help — Cette aide\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
-        "*🔘 Boutons & mots-clés*\n"
-        "Stats · Historique · Interroger\n"
-        "Corriger · Supprimer · Menu\n"
-        "Confirmer · Annuler\n\n"
+        "*💡 Aide ciblée par domaine*\n"
+        f"  {_HELP_MOTS_CLES}\n"
+        "Exemple : /help parcelle\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
         "*🔍 Exemples de questions*\n"
         "• _\"Combien de kg de tomates récoltés ?\"_\n"
@@ -401,6 +566,17 @@ async def handle_voice(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if intent == "HISTORIQUE":
         await msg.edit_text("📋 *Historique*", parse_mode="Markdown")
         await cmd_historique(update, ctx)
+        return
+    # [US_Plan_occupation_parcelles / CA9] Routage vocal PLAN
+    if intent == "PLAN":
+        await msg.edit_text("🗺 *Plan du potager...*", parse_mode="Markdown")
+        parcelle_vocal = _extract_plan_parcelle(texte)
+        if parcelle_vocal:
+            log.info(f"🗺 PLAN VOCAL PARCELLE : parcelle='{parcelle_vocal}'")
+            ctx.args = [parcelle_vocal]
+        else:
+            ctx.args = []
+        await cmd_plan(update, ctx)
         return
     if intent == "INTERROGER":
         # Si le texte est déjà une question complète (>4 mots), la traiter directement
@@ -508,6 +684,7 @@ INTENTS = {
     "MENU",         # retour accueil, menu
     "NOUVELLE",     # nouvelle action, autre chose
     "ACTION",       # action potager à enregistrer (récolte, semis, arrosage...)
+    "PLAN",         # [US_Plan_occupation_parcelles / CA9] plan d'occupation parcelles
 }
 
 _CLASSIFY_PROMPT = """Tu es un assistant potager. L'utilisateur t'envoie un message (transcrit vocalement ou tapé).
@@ -520,6 +697,7 @@ Classe ce message dans UNE SEULE catégorie parmi :
 - MENU        : veut revenir au menu, accueil, annuler
 - NOUVELLE    : veut saisir une nouvelle action (après une autre)
 - ACTION      : décrit une action potager réellement RÉALISÉE à enregistrer (récolte, semis, plantation, arrosage, paillage, traitement, observation, fertilisation, taille, tuteurage, repiquage, désherbage, perte, mise_en_godet)
+- PLAN        : veut voir le plan d'occupation des parcelles (plan du potager, plan parcelle X)
 
 RÈGLE IMPORTANTE : si le message contient "afficher", "montrer", "voir", "liste", "consulter", "quand", "combien", "quel" → c'est INTERROGER ou HISTORIQUE, jamais ACTION.
 
@@ -532,10 +710,13 @@ Exemples :
 - "récolte 500g de carotte nantaise hier" → ACTION
 - "semis de radis 50 graines" → ACTION
 - "quand ai-je semé les carottes" → INTERROGER
+- "plan du potager" → PLAN
+- "plan parcelle nord" → PLAN
+- "montre-moi le plan" → PLAN
 
 Message : "{texte}"
 
-Réponds avec UN SEUL MOT en majuscules parmi : STATS, HISTORIQUE, INTERROGER, CORRIGER, SUPPRIMER, MENU, NOUVELLE, ACTION
+Réponds avec UN SEUL MOT en majuscules parmi : STATS, HISTORIQUE, INTERROGER, CORRIGER, SUPPRIMER, MENU, NOUVELLE, ACTION, PLAN
 Réponse :"""
 
 def classify_intent(texte: str) -> str:
@@ -579,6 +760,29 @@ def _extract_stats_culture(texte: str) -> str | None:
     return m.group(1) if m else None
 
 
+def _extract_plan_parcelle(texte: str) -> str | None:
+    """
+    [US_Plan_occupation_parcelles / CA9]
+    Extrait le nom de parcelle depuis une phrase vocale type 'plan parcelle nord'.
+
+    Exemples reconnus :
+      "plan du potager"     → None  (vue globale)
+      "plan parcelle nord"  → "nord"
+      "plan nord"           → "nord"
+    """
+    m = re.search(
+        r'plan\s+(?:parcelle\s+)?(\w+)',
+        texte.lower().strip(),
+    )
+    if m:
+        mot = m.group(1)
+        # Ignorer les mots génériques qui ne sont pas des noms de parcelle
+        if mot in {"du", "des", "le", "la", "les", "potager", "jardin"}:
+            return None
+        return mot
+    return None
+
+
 async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     """Message texte → parsing direct ou commande de navigation."""
     texte_raw = update.message.text.strip()
@@ -586,7 +790,7 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     log.info(f"💬 MESSAGE TEXTE  : {texte_raw}")
 
     # Réinitialiser le mode SAUF si on est en plein flux de correction ou en attente de question
-    MODES_CORRECTION = {'corr_select', 'corr_apply', 'corr_search', 'corr_confirm_delete', 'corr_confirm', 'ask'}
+    MODES_CORRECTION = {'corr_select', 'corr_apply', 'corr_search', 'corr_confirm_delete', 'corr_confirm', 'ask', 'parcelle_confirm'}
     if ctx.user_data.get('mode') not in MODES_CORRECTION:
         ctx.user_data['mode'] = None
 
@@ -663,6 +867,43 @@ async def handle_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         log.info(f"❓ MODE ASK        : reroutage → _ask_question")
         await _ask_question(update, texte_raw)
         return
+
+    # ── PRIORITÉ 2b : confirmation parcelle en attente [US_Plan_occupation_parcelles / CA12, CA13]
+    if mode == 'parcelle_confirm':
+        pending = ctx.user_data.get('parcelle_pending', {})
+        ctx.user_data.pop('parcelle_pending', None)
+        ctx.user_data['mode'] = None
+        reponse = texte.strip().lower()
+        if reponse in {"oui", "o", "yes", "y"}:
+            nom = pending.get("nom", "")
+            if nom:
+                try:
+                    db = SessionLocal()
+                    try:
+                        new_p = create_parcelle(
+                            db, nom,
+                            exposition=pending.get("exposition"),
+                            superficie_m2=pending.get("superficie_m2"),
+                        )
+                        log.info(f"[US_Plan_occupation_parcelles] Parcelle confirmée : {new_p.nom!r}")
+                        details = []
+                        if new_p.exposition:
+                            details.append(f"exposition {new_p.exposition}")
+                        if new_p.superficie_m2 is not None:
+                            details.append(f"{new_p.superficie_m2} m²")
+                        detail_str = f" ({', '.join(details)})" if details else ""
+                        await update.message.reply_text(
+                            f"✅ Parcelle *{new_p.nom.upper()}* créée{detail_str}.",
+                            parse_mode="Markdown",
+                        )
+                    finally:
+                        db.close()
+                except ValueError as e:
+                    await update.message.reply_text(f"❌ {e}", parse_mode="Markdown")
+            return
+        else:
+            await update.message.reply_text("↩️ Création annulée.", parse_mode="Markdown")
+            return
 
     # ── PRIORITÉ 3 : mots-clés correction/suppression
     if texte in NAV_SUPPRIMER or any(texte.startswith(k) for k in ["supprimer", "effacer", "annuler"]):
@@ -829,13 +1070,28 @@ async def _parse_and_save(update: Update, texte: str, msg=None):
     saved_items = []
     try:
         for parsed in items:
+            # ── Résolution FK parcelle ────────────────────────────────────────
+            nom_parcelle = parsed.get("parcelle")
+            parcelle_obj = None
+            if nom_parcelle:
+                parcelle_obj = resolve_parcelle(db, nom_parcelle)
+                if parcelle_obj is None:
+                    log.warning(f"⚠️ PARCELLE INCONNUE : {nom_parcelle!r} — sauvegarde bloquée")
+                    err_msg = (
+                        f"❌ La parcelle *{nom_parcelle}* n'existe pas dans votre potager.\n\n"
+                        f"Créez-la d'abord avec : `/parcelle ajouter {nom_parcelle}`"
+                    )
+                    if msg:  await msg.edit_text(err_msg, parse_mode="Markdown")
+                    else:    await update.message.reply_text(err_msg, parse_mode="Markdown", reply_markup=MENU_KEYBOARD)
+                    return
             event = Evenement(
                 type_action       = normalize_action(parsed.get("action")),
                 culture           = parsed.get("culture"),
                 variete           = parsed.get("variete"),
                 quantite          = _to_float(parsed.get("quantite")),
                 unite             = parsed.get("unite"),
-                parcelle          = parsed.get("parcelle"),
+                parcelle          = parcelle_obj.nom if parcelle_obj else None,
+                parcelle_id       = parcelle_obj.id  if parcelle_obj else None,
                 rang              = _to_int(parsed.get("rang")),
                 duree             = _to_int(parsed.get("duree_minutes")),
                 traitement        = parsed.get("traitement"),
@@ -848,7 +1104,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None):
             db.add(event)
             db.commit()
             db.refresh(event)
-            log.info(f"💾 DB SAVE        : id={event.id} | action={event.type_action} | culture={event.culture} | qte={event.quantite} {event.unite or ''} | rang={event.rang} | parcelle={event.parcelle} | date={event.date}")
+            log.info(f"💾 DB SAVE        : id={event.id} | action={event.type_action} | culture={event.culture} | qte={event.quantite} {event.unite or ''} | rang={event.rang} | parcelle={event.parcelle} (id={event.parcelle_id}) | date={event.date}")
             saved_items.append((parsed, event.id))
     except Exception as e:
         db.rollback()
@@ -1020,6 +1276,390 @@ async def _ask_question(update: Update, question: str):
 
 
 # ── COMMANDES ───────────────────────────────────────────────────────────────────
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA1-CA7, CA9] Commande /plan
+# ──────────────────────────────────────────────────────────────────────────────
+
+# [US_Plan_occupation_parcelles / CA3] Seuils d'alerte par type d'organe (jours)
+SEUIL_ALERTE = {"végétatif": 45, "reproducteur": 90}
+
+# [US_Plan_occupation_parcelles] Emoji par type d'organe
+_EMOJI_ORGANE = {"reproducteur": "🍅", "végétatif": "🥬"}
+_EMOJI_INCONNU = "🌱"
+
+
+async def cmd_plan(update, ctx) -> None:
+    """
+    /plan [parcelle] — Plan d'occupation du potager.
+
+    [CA1] Vue globale : cultures actives par parcelle avec variété et nb plants
+    [CA2] Âge J+ depuis la première plantation
+    [CA3] Alerte ⚠️ si âge > seuil typique (végétatif ≥ 45j, reproducteur ≥ 90j)
+    [CA4] Parcelles libres affichées 🟢 [NOM] — Libre
+    [CA5] /plan nord filtre sur la parcelle "nord" (insensible à la casse)
+    [CA6] Hint en pied de message
+    [CA7] Cultures sans parcelle sous 📍 Non localisé
+    """
+    from datetime import date as date_type
+    db = SessionLocal()
+    try:
+        occupation = calcul_occupation_parcelles(db)
+        parcelles_bdd = get_all_parcelles(db)
+
+        # ── Filtre parcelle spécifique (CA5) ──────────────────────────────────
+        filtre_arg = (ctx.args[0].strip().lower() if ctx.args else None)
+
+        if filtre_arg:
+            # Vue détaillée d'une parcelle
+            cles_norm = {
+                (k.strip().lower() if k else None): k
+                for k in occupation
+            }
+            cle_originale = cles_norm.get(filtre_arg)
+
+            if cle_originale is None and cle_originale not in occupation:
+                # Chercher dans toutes les clés normalisées
+                for k in occupation:
+                    if k and k.strip().lower() == filtre_arg:
+                        cle_originale = k
+                        break
+
+            cultures = occupation.get(cle_originale, [])
+            if not cultures:
+                await update.message.reply_text(
+                    f"Aucune culture active sur la parcelle *{filtre_arg.upper()}*.",
+                    parse_mode="Markdown",
+                )
+                return
+
+            nom_affiche = (cle_originale or filtre_arg).upper()
+            lignes = [f"📍 *{nom_affiche}* — Plan détaillé\n"]
+            for c in sorted(cultures, key=lambda x: x["culture"]):
+                alerte = _alerte_recolte(c["type_organe"], c["age_jours"])
+                emoji = _EMOJI_ORGANE.get(c["type_organe"], _EMOJI_INCONNU)
+                var = f" {c['variete']}" if c["variete"] else ""
+                nb = int(c["nb_plants"])
+                unite = c["unite"] or "plants"
+                date_str = (
+                    c["date_plantation"].strftime("%d %b").lstrip("0")
+                    if c["date_plantation"] else "?"
+                )
+                lignes.append(
+                    f"{emoji} *{c['culture']}{var}*\n"
+                    f"  {nb} {unite} actifs · plantés le {date_str} (J+{c['age_jours']})"
+                )
+                if c["type_organe"]:
+                    lignes.append(f"  Type : {c['type_organe']}")
+                if alerte:
+                    seuil = SEUIL_ALERTE.get(c["type_organe"], 0)
+                    lignes.append(f"  ⚠️ Récolte imminente ({c['type_organe']} > {seuil} j)")
+
+            lignes.append(
+                f"\n_Historique de rotation : \"rotation parcelle {filtre_arg}\"_"
+            )
+            await update.message.reply_text("\n".join(lignes), parse_mode="Markdown")
+            await send_voice_reply(update, f"Détail de la parcelle {filtre_arg}")
+            return
+
+        # ── Vue globale ────────────────────────────────────────────────────────
+        today = date_type.today()
+        date_str = today.strftime("%d %b %Y").lstrip("0") if hasattr(today, "strftime") else str(today)
+
+        lignes = [f"📋 *Plan d'occupation — {date_str}*\n"]
+
+        # Parcelles connues en BDD → ordre défini
+        noms_bdd = {p.nom.strip().lower(): p.nom for p in parcelles_bdd}
+        affichees: set = set()
+
+        def _bloc_parcelle(nom_cle, cultures_liste: list) -> list:
+            """Formate le bloc d'une parcelle avec ses cultures."""
+            bloc = []
+            nom_affiche = (nom_cle or "").upper()
+            nb = len(cultures_liste)
+            bloc.append(f"📍 *{nom_affiche}* · {nb} culture{'s' if nb > 1 else ''} active{'s' if nb > 1 else ''}")
+            for c in sorted(cultures_liste, key=lambda x: x["culture"]):
+                emoji = _EMOJI_ORGANE.get(c["type_organe"], _EMOJI_INCONNU)
+                var = f" {c['variete']}" if c["variete"] else ""
+                nb_plants = int(c["nb_plants"])
+                unite = c["unite"] or "plants"
+                alerte = _alerte_recolte(c["type_organe"], c["age_jours"])
+                alerte_str = " ⚠️ récolte imminente" if alerte else ""
+                bloc.append(
+                    f"  {emoji} {c['culture']}{var} — {nb_plants} {unite} · J+{c['age_jours']}{alerte_str}"
+                )
+            return bloc
+
+        # Parcelles BDD actives (ordonnées)
+        for p in parcelles_bdd:
+            nom_key = p.nom.strip()
+            nom_lower = nom_key.lower()
+            affichees.add(nom_lower)
+
+            cultures = occupation.get(nom_key, [])
+            # Essai avec la clé telle quelle, puis en ignorant la casse
+            if not cultures:
+                for k in occupation:
+                    if k and k.strip().lower() == nom_lower:
+                        cultures = occupation[k]
+                        break
+
+            if cultures:
+                lignes.extend(_bloc_parcelle(nom_key, cultures))
+            else:
+                # [CA4] Parcelle libre
+                lignes.append(f"🟢 *{nom_key.upper()}* — Libre")
+            lignes.append("")  # ligne vide entre parcelles
+
+        # Parcelles dans occupation mais pas en BDD (non référencées)
+        for nom_cle, cultures in occupation.items():
+            if nom_cle is None:
+                continue
+            if nom_cle.strip().lower() not in affichees:
+                lignes.extend(_bloc_parcelle(nom_cle, cultures))
+                lignes.append("")
+
+        # [CA7] Cultures sans parcelle
+        sans_parcelle = occupation.get(None, [])
+        if sans_parcelle:
+            nb = len(sans_parcelle)
+            lignes.append(f"📍 *Non localisé* · {nb} culture{'s' if nb > 1 else ''}")
+            for c in sorted(sans_parcelle, key=lambda x: x["culture"]):
+                emoji = _EMOJI_ORGANE.get(c["type_organe"], _EMOJI_INCONNU)
+                var = f" {c['variete']}" if c["variete"] else ""
+                nb_plants = int(c["nb_plants"])
+                unite = c["unite"] or "plants"
+                alerte = _alerte_recolte(c["type_organe"], c["age_jours"])
+                alerte_str = " ⚠️ récolte imminente" if alerte else ""
+                lignes.append(
+                    f"  {emoji} {c['culture']}{var} — {nb_plants} {unite} · J+{c['age_jours']}{alerte_str}"
+                )
+            lignes.append("")
+
+        # [CA6] Pied du message
+        lignes.append("_Pour le détail : /plan [nom parcelle]_")
+        lignes.append("_Historique de rotation : \"rotation parcelle X\"_")
+
+        texte_final = "\n".join(lignes).strip()
+        await update.message.reply_text(texte_final, parse_mode="Markdown")
+        await send_voice_reply(update, "Plan du potager affiché")
+
+    except Exception as e:
+        log.error(f"[US_Plan_occupation_parcelles] cmd_plan erreur : {e}")
+        await update.message.reply_text(f"❌ Erreur : {e}", reply_markup=MENU_KEYBOARD)
+    finally:
+        db.close()
+
+
+def _alerte_recolte(type_organe: str | None, age_jours: int) -> bool:
+    """[CA3] Retourne True si la culture dépasse le seuil d'alerte."""
+    if type_organe and type_organe in SEUIL_ALERTE:
+        return age_jours >= SEUIL_ALERTE[type_organe]
+    return False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA10, CA12, CA13] Commande /parcelle
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def cmd_parcelle(update, ctx) -> None:
+    """
+    /parcelle <sous-commande> — Gestion des parcelles.
+
+    Sous-commandes :
+      ajouter [nom] [exposition] [superficie]  — créer une parcelle (CA10, CA12, CA13)
+      modifier [nom] clé=valeur ...             — mettre à jour les métadonnées
+      lister                                    — afficher toutes les parcelles
+    """
+    USAGE = (
+        "*Usage :*\n"
+        "  /parcelle ajouter [nom] [exposition] [superficie]\n"
+        "  /parcelle modifier [nom] exposition=sud superficie=8.5\n"
+        "  /parcelle lister\n\n"
+        "Exemples :\n"
+        "  /parcelle ajouter nord sud 12.5\n"
+        "  /parcelle modifier nord exposition=sud superficie=8.5"
+    )
+
+    if not ctx.args:
+        await update.message.reply_text(USAGE, parse_mode="Markdown")
+        return
+
+    sous_cmd = ctx.args[0].lower()
+
+    # ── /parcelle lister ──────────────────────────────────────────────────────
+    if sous_cmd == "lister":
+        db = SessionLocal()
+        try:
+            parcelles = get_all_parcelles(db)
+            if not parcelles:
+                await update.message.reply_text(
+                    "📋 Aucune parcelle enregistrée.\n"
+                    "Créez-en une : /parcelle ajouter [nom]",
+                    parse_mode="Markdown",
+                )
+                return
+            lignes = [f"📋 *Parcelles enregistrées ({len(parcelles)})*\n"]
+            for p in parcelles:
+                details = []
+                if p.exposition:
+                    details.append(f"exposition {p.exposition}")
+                if p.superficie_m2 is not None:
+                    details.append(f"{p.superficie_m2} m²")
+                detail_str = f" · {' · '.join(details)}" if details else ""
+                lignes.append(f"📍 *{p.nom.upper()}*{detail_str}")
+            lignes.append("\n_Ajouter : /parcelle ajouter [nom] [exposition] [superficie]_")
+            lignes.append("_Modifier : /parcelle modifier [nom] clé=valeur_")
+            await update.message.reply_text("\n".join(lignes), parse_mode="Markdown")
+        except Exception as e:
+            log.error(f"[US_Plan_occupation_parcelles] cmd_parcelle lister erreur : {e}")
+            await update.message.reply_text(f"❌ Erreur : {e}")
+        finally:
+            db.close()
+        return
+
+    # ── /parcelle modifier [nom] clé=valeur ... ───────────────────────────────
+    if sous_cmd == "modifier":
+        if len(ctx.args) < 3:
+            await update.message.reply_text(
+                "❌ Usage : /parcelle modifier [nom] clé=valeur ...\n"
+                "Exemple : /parcelle modifier nord exposition=sud superficie=8.5",
+                parse_mode="Markdown",
+            )
+            return
+
+        nom = ctx.args[1].strip()
+        kwargs: dict = {}
+        for token in ctx.args[2:]:
+            if "=" in token:
+                k, _, v = token.partition("=")
+                kwargs[k.lower().strip()] = v.strip()
+            else:
+                await update.message.reply_text(
+                    f"❌ Paramètre invalide : *{token}*\n"
+                    "Format attendu : clé=valeur (ex : exposition=sud)",
+                    parse_mode="Markdown",
+                )
+                return
+
+        db = SessionLocal()
+        try:
+            parc, modifs = update_parcelle(db, nom, **kwargs)
+            lignes = [f"✅ Parcelle *{parc.nom.upper()}* mise à jour :"]
+            for m in modifs:
+                lignes.append(f"  · {m}")
+            await update.message.reply_text("\n".join(lignes), parse_mode="Markdown")
+        except LookupError:
+            all_p = get_all_parcelles(db)
+            noms = ", ".join(p.nom.lower() for p in all_p) or "(aucune)"
+            await update.message.reply_text(
+                f"❌ Parcelle *{nom}* introuvable.\nParcelles connues : {noms}",
+                parse_mode="Markdown",
+            )
+        except ValueError as e:
+            await update.message.reply_text(f"❌ {e}", parse_mode="Markdown")
+        except Exception as e:
+            log.error(f"[US_Plan_occupation_parcelles] cmd_parcelle modifier erreur : {e}")
+            await update.message.reply_text(f"❌ Erreur : {e}")
+        finally:
+            db.close()
+        return
+
+    # ── /parcelle ajouter [nom] [exposition] [superficie] ─────────────────────
+    if sous_cmd == "ajouter":
+        if len(ctx.args) < 2:
+            await update.message.reply_text(
+                "❌ Précisez le nom de la parcelle.\nExemple : /parcelle ajouter nord",
+                parse_mode="Markdown",
+            )
+            return
+
+        nom = ctx.args[1].strip()
+        # Parsing optionnel : arg[2]=exposition (texte), arg[3]=superficie (float)
+        exposition: str | None = None
+        superficie_m2: float | None = None
+        extra = ctx.args[2:]
+        for tok in extra:
+            try:
+                superficie_m2 = float(tok.replace(",", "."))
+            except ValueError:
+                exposition = tok
+
+        nom_normalise = normalize_parcelle_name(nom)
+
+        db = SessionLocal()
+        try:
+            exact, proche = find_doublon(db, nom_normalise)
+
+            # [CA10] Doublon exact
+            if exact:
+                log.info(f"[US_Plan_occupation_parcelles] Doublon exact : {nom!r} → {exact.nom!r}")
+                await update.message.reply_text(
+                    f"❌ La parcelle *{exact.nom.upper()}* existe déjà.\n"
+                    "Utilisez /plan pour consulter les parcelles existantes.",
+                    parse_mode="Markdown",
+                )
+                return
+
+            # [CA12] Variante proche
+            if proche:
+                log.info(f"[US_Plan_occupation_parcelles] Variante proche : {nom!r} ≈ {proche.nom!r}")
+                ctx.user_data['mode'] = 'parcelle_confirm'
+                ctx.user_data['parcelle_pending'] = {
+                    "nom": nom,
+                    "exposition": exposition,
+                    "superficie_m2": superficie_m2,
+                }
+                await update.message.reply_text(
+                    f"⚠️ Une parcelle similaire existe : *{proche.nom.upper()}*.\n"
+                    f"Confirmer la création de *{nom.upper()}* ? _(oui / non)_",
+                    parse_mode="Markdown",
+                )
+                return
+
+            # [CA13] Pas de doublon → récapitulatif + confirmation
+            parcelles_existantes = get_all_parcelles(db)
+            lignes = ["📋 *Parcelles existantes :*"]
+            for p in parcelles_existantes:
+                lignes.append(f"  · {p.nom.upper()}")
+            if not parcelles_existantes:
+                lignes.append("  _(aucune pour l'instant)_")
+
+            detail_parts = []
+            if exposition:
+                detail_parts.append(f"exposition : {exposition}")
+            if superficie_m2 is not None:
+                detail_parts.append(f"superficie : {superficie_m2} m²")
+            detail_conf = f" ({', '.join(detail_parts)})" if detail_parts else ""
+            lignes.append(
+                f"\n➕ Créer la parcelle *{nom.upper()}*{detail_conf} ? _(oui / non)_"
+            )
+
+            ctx.user_data['mode'] = 'parcelle_confirm'
+            ctx.user_data['parcelle_pending'] = {
+                "nom": nom,
+                "exposition": exposition,
+                "superficie_m2": superficie_m2,
+            }
+            await update.message.reply_text("\n".join(lignes), parse_mode="Markdown")
+
+        except Exception as e:
+            log.error(f"[US_Plan_occupation_parcelles] cmd_parcelle ajouter erreur : {e}")
+            await update.message.reply_text(f"❌ Erreur : {e}", reply_markup=MENU_KEYBOARD)
+        finally:
+            db.close()
+        return
+
+    # Sous-commande inconnue
+    await update.message.reply_text(USAGE, parse_mode="Markdown")
+
+
+async def _cmd_parcelles_lister(update, ctx) -> None:
+    """Alias /parcelles → /parcelle lister."""
+    ctx.args = ["lister"]
+    await cmd_parcelle(update, ctx)
+
+
 async def cmd_stats(update, ctx):
     """
     /stats — Statistiques rapides du potager.
@@ -1297,11 +1937,12 @@ def _fmt_event(e) -> str:
     d    = e.date.strftime("%d/%m") if e.date else "?"
     act  = e.type_action or "?"
     cult = f" {e.culture}" if e.culture else ""
+    var  = f" ({e.variete})" if e.variete else ""
     qte  = f" {e.quantite}{e.unite or ''}" if e.quantite else ""
     parc = f" [{e.parcelle}]" if e.parcelle else ""
     rang = f" x{e.rang}rangs" if e.rang else ""
     trt  = f" ({e.traitement})" if e.traitement else ""
-    return f"#{e.id} {d} — {act}{cult}{qte}{rang}{parc}{trt}"
+    return f"#{e.id} {d} — {act}{cult}{var}{qte}{rang}{parc}{trt}"
 
 
 def _normalize_action_search(action: str) -> str:
@@ -1341,11 +1982,12 @@ L'utilisateur veut retrouver un événement potager.
 Description : "{description}"
 
 Retourne UNIQUEMENT ce JSON (null si non mentionné) :
-{{"action": string|null, "culture": string|null, "date_debut": "YYYY-MM-DD"|null, "date_fin": "YYYY-MM-DD"|null, "parcelle": string|null}}
+{{"action": string|null, "culture": string|null, "variete": string|null, "date_debut": "YYYY-MM-DD"|null, "date_fin": "YYYY-MM-DD"|null, "parcelle": string|null}}
 
 RÈGLES :
 - action SANS accent : recolte, plantation, semis, arrosage, paillage, traitement, desherbage, taille, observation, tuteurage, fertilisation, repiquage
 - culture au singulier minuscule sans accent
+- variete : mot ou groupe de mots décrivant la variété (ex: "ronde", "cerise", "noire de crimée"), null si non mentionné
 - "11 mars" ou "11 mars dernier" → date_debut="{today.year}-03-11", date_fin="{today.year}-03-11"  
 - "la semaine dernière" → date_debut="{last_week}", date_fin="{today.isoformat()}"
 - "ce mois" → date_debut="{last_month}", date_fin="{today.isoformat()}"
@@ -1380,6 +2022,8 @@ JSON brut uniquement."""
             q = q.filter(Evenement.type_action == criteres["action"])
         if criteres.get("culture"):
             q = q.filter(Evenement.culture.ilike(f"%{criteres['culture']}%"))
+        if criteres.get("variete"):
+            q = q.filter(Evenement.variete.ilike(f"%{criteres['variete']}%"))
         if criteres.get("parcelle"):
             q = q.filter(Evenement.parcelle.ilike(f"%{criteres['parcelle']}%"))
         if criteres.get("date_debut"):
@@ -1711,6 +2355,28 @@ JSON brut uniquement."""
         )
         return
 
+    # ── Validation FK parcelle ────────────────────────────────────────────────
+    nom_parcelle_corr = corrections.get("parcelle")
+    if nom_parcelle_corr is not None:
+        db_check = SessionLocal()
+        try:
+            parcelle_resolue = resolve_parcelle(db_check, nom_parcelle_corr)
+        finally:
+            db_check.close()
+        if parcelle_resolue is None:
+            log.warning(f"⚠️ CORRECTION BLOQUÉE : parcelle inconnue {nom_parcelle_corr!r}")
+            await msg_wait.edit_text(
+                f"❌ La parcelle *{nom_parcelle_corr}* n'existe pas dans votre potager.\n\n"
+                f"Créez-la d'abord avec : `/parcelle ajouter {nom_parcelle_corr}`",
+                parse_mode="Markdown"
+            )
+            # Rester en corr_apply pour permettre une nouvelle correction
+            return
+        # Normaliser le nom vers la forme canonique de la BDD
+        corrections["parcelle"] = parcelle_resolue.nom
+        corrections["_parcelle_id"] = parcelle_resolue.id
+        log.info(f"✅ PARCELLE RÉSOLUE : {nom_parcelle_corr!r} → {parcelle_resolue.nom!r} (id={parcelle_resolue.id})")
+
     log.info(f"✏️ CORRECTIONS     : {corrections}")
 
     # Préparer le résumé lisible avant confirmation
@@ -1729,6 +2395,8 @@ JSON brut uniquement."""
 
     lines = [f"📋 *Résumé des modifications sur #{event_id} :*\n"]
     for champ, nouvelle_val in corrections.items():
+        if champ.startswith("_"):   # champs internes (_parcelle_id…)
+            continue
         ancienne_val = event_actuel.get(champ, "—") or "—"
         label = LABELS.get(champ, champ)
         lines.append(f"• *{label}* : `{ancienne_val}` → `{nouvelle_val if nouvelle_val is not None else 'supprimé'}`")
@@ -1790,6 +2458,9 @@ async def _corr_confirm(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: s
         try:
             event = db.get(Evenement, event_id)
             for champ, valeur in corrections.items():
+                if champ == "_parcelle_id":
+                    # champ interne — géré ci-dessous avec "parcelle"
+                    continue
                 col = mapping.get(champ, champ)
                 if champ == "date":
                     setattr(event, "date", parse_date(valeur))
@@ -1797,6 +2468,10 @@ async def _corr_confirm(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: s
                     setattr(event, col, _to_float(valeur))
                 elif champ in ("rang", "duree_minutes"):
                     setattr(event, col, _to_int(valeur))
+                elif champ == "parcelle":
+                    # Mettre à jour le texte ET la FK parcelle_id
+                    event.parcelle    = valeur
+                    event.parcelle_id = corrections.get("_parcelle_id")
                 elif hasattr(event, col):
                     setattr(event, col, valeur)
 
@@ -1810,6 +2485,7 @@ async def _corr_confirm(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: s
             details = ", ".join(
                 f"{LABELS.get(k, k)}: {event_actuel.get(k, '—') or '—'} → {v if v is not None else 'supprimé'}"
                 for k, v in corrections.items()
+                if not k.startswith("_")   # ignorer champs internes (_parcelle_id…)
             )
             trace = f" | [CORR {date.today().isoformat()}] {details}"
             event.texte_original = (event.texte_original or "") + trace
@@ -1942,6 +2618,11 @@ def main():
 
     # Commande météo manuelle
     app.add_handler(CommandHandler("meteo",      cmd_meteo))
+
+    # [US_Plan_occupation_parcelles / CA1, CA13] Plan et gestion des parcelles
+    app.add_handler(CommandHandler("plan",      cmd_plan))
+    app.add_handler(CommandHandler("parcelle",  cmd_parcelle))
+    app.add_handler(CommandHandler("parcelles", _cmd_parcelles_lister))  # alias /parcelle lister
 
     # Messages
     app.add_handler(MessageHandler(filters.VOICE, handle_voice))

--- a/database/models.py
+++ b/database/models.py
@@ -4,7 +4,7 @@ database/models.py — Modèles SQLAlchemy pour l'Assistant Potager
 [US-001] Ajout colonne type_organe_recolte sur Evenement
 [US-001] Ajout modèle CultureConfig (table culture_config)
 """
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, ForeignKey
 from database.db import Base
 
 
@@ -29,6 +29,7 @@ class Evenement(Base):
 
     # Localisation
     parcelle       = Column(String, index=True)
+    parcelle_id    = Column(Integer, ForeignKey("parcelles.id"), nullable=True, index=True)
     rang           = Column(Integer)   # [migration_v3] INTEGER (pas String)
 
     # Détails
@@ -64,3 +65,23 @@ class CultureConfig(Base):
     nom                     = Column(String, unique=True, index=True, nullable=False)
     type_organe_recolte     = Column(String, nullable=False)   # "végétatif" | "reproducteur"
     description_agronomique = Column(String)
+
+
+class Parcelle(Base):
+    """
+    [US_Plan_occupation_parcelles / CA8]
+    Représente une parcelle physique du potager.
+
+    - nom_normalise : forme canonique unique (strip + lower + unidecode + sans tirets/espaces)
+    - ordre         : position pour l'affichage trié du plan
+    - actif         : permet de désactiver sans supprimer
+    """
+    __tablename__ = "parcelles"
+
+    id            = Column(Integer, primary_key=True, index=True)
+    nom           = Column(String, nullable=False)
+    nom_normalise = Column(String, unique=True, nullable=False, index=True)
+    exposition    = Column(String, nullable=True)
+    superficie_m2 = Column(Float, nullable=True)
+    ordre         = Column(Integer, default=0)
+    actif         = Column(Boolean, default=True, nullable=False)

--- a/migrations/migration_v10.sql
+++ b/migrations/migration_v10.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- migration_v10.sql — Table parcelles (US_Plan_occupation_parcelles)
+-- =============================================================================
+-- Crée la table `parcelles` pour gérer les parcelles physiques du potager.
+-- Idempotent : utilise IF NOT EXISTS / ON CONFLICT, safe à rejouer.
+--
+-- Exécution depuis psql :
+--   psql -U potager_user -d potager -f migration_v10.sql
+-- =============================================================================
+
+-- [CA8] Création de la table parcelles
+CREATE TABLE IF NOT EXISTS parcelles (
+    id            SERIAL PRIMARY KEY,
+    nom           VARCHAR(255) NOT NULL,
+    nom_normalise VARCHAR(255) UNIQUE NOT NULL,
+    exposition    VARCHAR(50),
+    superficie_m2 FLOAT,
+    ordre         INTEGER DEFAULT 0,
+    actif         BOOLEAN DEFAULT TRUE NOT NULL
+);
+
+-- Index sur nom_normalise pour les recherches rapides (CA10, CA11, CA12)
+CREATE INDEX IF NOT EXISTS ix_parcelles_nom_normalise ON parcelles(nom_normalise);
+
+-- [CA8] Prépopuler depuis les parcelles déjà utilisées dans evenements
+-- Nécessite l'extension unaccent (activée par défaut sur PostgreSQL 13+)
+-- SI unaccent n'est pas disponible : CREATE EXTENSION IF NOT EXISTS unaccent;
+INSERT INTO parcelles (nom, nom_normalise, ordre)
+SELECT DISTINCT
+    parcelle,
+    lower(regexp_replace(unaccent(parcelle), '[\s\-]+', '', 'g')),
+    ROW_NUMBER() OVER (ORDER BY parcelle)
+FROM evenements
+WHERE parcelle IS NOT NULL
+  AND parcelle <> ''
+ON CONFLICT (nom_normalise) DO NOTHING;
+
+-- Vérification post-migration
+SELECT id, nom, nom_normalise, ordre, actif
+FROM parcelles
+ORDER BY ordre;
+-- Attendu : autant de lignes que de parcelles distinctes dans evenements

--- a/migrations/migration_v11.sql
+++ b/migrations/migration_v11.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- migration_v11.sql — Ajout FK parcelle_id sur evenements
+-- =============================================================================
+-- Relie la colonne texte `parcelle` à la table `parcelles` via une clé étrangère.
+-- Idempotent : utilise IF NOT EXISTS / ON CONFLICT, safe à rejouer.
+--
+-- Prérequis : migration_v10.sql (table parcelles) doit être appliquée.
+--
+-- Exécution depuis psql :
+--   psql -U potager_user -d potager -f migration_v11.sql
+-- =============================================================================
+
+-- [1] Ajout de la colonne FK (nullable pour rétrocompatibilité avec l'historique)
+ALTER TABLE evenements
+    ADD COLUMN IF NOT EXISTS parcelle_id INTEGER REFERENCES parcelles(id);
+
+-- Index pour les jointures et filtres par parcelle
+CREATE INDEX IF NOT EXISTS ix_evenements_parcelle_id ON evenements(parcelle_id);
+
+-- [2] Rétro-remplissage : résoudre le texte libre `parcelle` vers parcelles.id
+--     via normalisation identique à normalize_parcelle_name() Python :
+--     lower + unaccent + suppression tirets/espaces
+UPDATE evenements e
+SET    parcelle_id = p.id
+FROM   parcelles p
+WHERE  lower(regexp_replace(unaccent(e.parcelle), '[\s\-]+', '', 'g'))
+       = p.nom_normalise
+  AND  e.parcelle     IS NOT NULL
+  AND  e.parcelle     <> ''
+  AND  e.parcelle_id  IS NULL;
+
+-- [3] Vérification post-migration
+SELECT
+    COUNT(*)                                        AS total_evenements,
+    COUNT(*) FILTER (WHERE parcelle IS NOT NULL)    AS avec_texte_parcelle,
+    COUNT(*) FILTER (WHERE parcelle_id IS NOT NULL) AS resolus_fk,
+    COUNT(*) FILTER (
+        WHERE parcelle IS NOT NULL
+          AND parcelle_id IS NULL
+    )                                               AS non_resolus
+FROM evenements;
+-- Attendu : non_resolus = 0 si toutes les parcelles du texte existent bien en table.

--- a/tests/test_bug_variete_recherche_affichage.py
+++ b/tests/test_bug_variete_recherche_affichage.py
@@ -1,0 +1,275 @@
+"""
+tests/test_bug_variete_recherche_affichage.py
+---------------------------------------------
+Couverture du BUG : Variété absente du critère de recherche et de l'affichage
+dans le mode correction.
+
+  - CA1 : critères extraits contiennent 'variete' quand la variété est mentionnée
+  - CA2 : filtre SQL sur Evenement.variete.ilike quand variete dans critères
+  - CA3 : filtre variété optionnel (null si non mentionné)
+  - CA4 : _fmt_event affiche la variété entre parenthèses
+  - CA5 : liste multi-résultats distingue les variétés
+  - Scénario : événement sans variété → pas de "()" vide
+"""
+import json
+import pytest
+from datetime import datetime, date
+from unittest.mock import patch, MagicMock
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.db import Base
+from database.models import Evenement
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=eng)
+    return eng
+
+
+@pytest.fixture
+def db(engine):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.rollback()
+    session.close()
+
+
+def _make_event(id_, action, culture, variete=None, parcelle=None, quantite=10.0):
+    return Evenement(
+        id=id_,
+        type_action=action,
+        culture=culture,
+        variete=variete,
+        parcelle=parcelle,
+        quantite=quantite,
+        unite="plants",
+        date=datetime(2026, 4, 7),
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _call_find_candidates_with_groq(description: str, groq_json: dict, db_session):
+    """
+    Appelle _find_candidates en mockant Groq + SessionLocal pour utiliser
+    la session de test.
+    """
+    from bot import _find_candidates
+
+    mock_resp = MagicMock()
+    mock_resp.choices[0].message.content = json.dumps(groq_json)
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    # Groq est importé localement dans _find_candidates via `from groq import Groq`
+    # → on patche groq.Groq pour intercepter cet import
+    with patch("groq.Groq", return_value=mock_client), \
+         patch("bot.SessionLocal", return_value=db_session):
+        results = _find_candidates(description)
+    return results
+
+
+# ── CA1 : critères extraits contiennent variete ───────────────────────────────
+
+class TestCA1_CriteresContiennentVariete:
+    """Groq retourne variete='ronde' quand l'utilisateur la mentionne."""
+
+    def test_variete_presente_dans_criteres(self, caplog, db):
+        """
+        CA1 : When "modifier plantation tomate ronde"
+        Then critères contiennent variete="ronde"
+        """
+        db.add(_make_event(1, "plantation", "tomate", variete="ronde"))
+        db.commit()
+
+        groq_json = {
+            "action": "plantation",
+            "culture": "tomate",
+            "variete": "ronde",
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="potager"):
+            results = _call_find_candidates_with_groq(
+                "modifier plantation tomate ronde", groq_json, db
+            )
+
+        assert "'variete': 'ronde'" in caplog.text or '"variete": "ronde"' in caplog.text, \
+            "Le log CRITÈRES RECHERCHE doit contenir variete='ronde'"
+
+
+# ── CA2 : filtre SQL sur variete ──────────────────────────────────────────────
+
+class TestCA2_FiltreSQLVariete:
+    """La requête SQL filtre sur variete.ilike quand variete est dans critères."""
+
+    def test_filtre_sql_variete_retourne_bonne_variete(self, db):
+        """
+        CA2 : deux plantations tomate avec des variétés différentes.
+        Quand variete='ronde', seule la plantation ronde est retournée.
+        """
+        db.add(_make_event(10, "plantation", "tomate", variete="ronde"))
+        db.add(_make_event(11, "plantation", "tomate", variete="cerise"))
+        db.commit()
+
+        groq_json = {
+            "action": "plantation",
+            "culture": "tomate",
+            "variete": "ronde",
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        results = _call_find_candidates_with_groq(
+            "modifier plantation tomate ronde", groq_json, db
+        )
+
+        ids = [e.id for e in results]
+        assert 10 in ids, "L'événement tomate ronde doit être retourné"
+        assert 11 not in ids, "L'événement tomate cerise ne doit PAS être retourné"
+
+
+# ── CA3 : filtre optionnel (sans variété) ────────────────────────────────────
+
+class TestCA3_FiltreVarieteOptionnel:
+    """Quand variete=null, la requête SQL ne filtre pas sur la variété."""
+
+    def test_sans_variete_tous_retournes(self, db):
+        """
+        CA3 : When "modifier plantation tomate" (sans variété)
+        Then tous les événements plantation tomate sont retournés
+        """
+        db.add(_make_event(20, "plantation", "tomate", variete="ronde"))
+        db.add(_make_event(21, "plantation", "tomate", variete="cerise"))
+        db.commit()
+
+        groq_json = {
+            "action": "plantation",
+            "culture": "tomate",
+            "variete": None,
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        results = _call_find_candidates_with_groq(
+            "modifier plantation tomate", groq_json, db
+        )
+
+        ids = [e.id for e in results]
+        assert 20 in ids
+        assert 21 in ids
+
+    def test_criteres_sans_variete_pas_de_filtre(self, caplog, db):
+        """CA3 : variete=null → log ne filtre pas la variété."""
+        groq_json = {
+            "action": "plantation",
+            "culture": "tomate",
+            "variete": None,
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="potager"):
+            _call_find_candidates_with_groq("modifier plantation tomate", groq_json, db)
+
+        # Le log CRITÈRES RECHERCHE doit afficher le dict complet avec variete
+        assert "CRITÈRES RECHERCHE" in caplog.text or "CRIT" in caplog.text
+
+
+# ── CA4 : _fmt_event affiche variété entre parenthèses ───────────────────────
+
+class TestCA4_FmtEventVariete:
+    """_fmt_event affiche la variété entre parenthèses après la culture."""
+
+    def test_variete_affichee(self):
+        """CA4 : événement avec variété → '… tomate (ronde) 10.0plants …'"""
+        from bot import _fmt_event
+
+        e = _make_event(247, "plantation", "tomate", variete="ronde")
+        result = _fmt_event(e)
+
+        assert "tomate (ronde)" in result, f"Attendu 'tomate (ronde)' dans : {result}"
+
+    def test_variete_position_avant_quantite(self):
+        """CA4 : variété apareît avant la quantité."""
+        from bot import _fmt_event
+
+        e = _make_event(247, "plantation", "tomate", variete="ronde", quantite=10.0)
+        result = _fmt_event(e)
+
+        idx_var = result.index("(ronde)")
+        idx_qte = result.index("10.0")
+        assert idx_var < idx_qte, "La variété doit apparaître avant la quantité"
+
+    def test_format_complet(self):
+        """CA4 : format exact '#247 07/04 — plantation tomate (ronde) 10.0plants'"""
+        from bot import _fmt_event
+
+        e = _make_event(247, "plantation", "tomate", variete="ronde", quantite=10.0)
+        result = _fmt_event(e)
+
+        assert result.startswith("#247"), f"Doit commencer par #247, obtenu : {result}"
+        assert "plantation tomate (ronde) 10.0plants" in result
+
+
+# ── CA5 : liste multi-résultats distingue les variétés ───────────────────────
+
+class TestCA5_ListeMultiVariete:
+    """Chaque ligne de la liste de sélection affiche la variété."""
+
+    def test_deux_varietes_distinctes_dans_liste(self):
+        """CA5 : _fmt_event sur deux événements de variétés différentes produit des lignes différentes."""
+        from bot import _fmt_event
+
+        e1 = _make_event(100, "plantation", "tomate", variete="ronde")
+        e2 = _make_event(101, "plantation", "tomate", variete="cerise")
+
+        line1 = _fmt_event(e1)
+        line2 = _fmt_event(e2)
+
+        assert "(ronde)" in line1
+        assert "(cerise)" in line2
+        assert line1 != line2, "Les deux lignes doivent être distinctes"
+
+
+# ── Scénario : événement sans variété → pas de "()" vide ─────────────────────
+
+class TestSansPrenthesesVides:
+    """Événement sans variété → aucun '()' vide dans l'affichage."""
+
+    def test_pas_de_parentheses_vides(self):
+        """Scénario : événement tomate sans variété → pas de '()'."""
+        from bot import _fmt_event
+
+        e = _make_event(162, "plantation", "tomate", variete=None)
+        result = _fmt_event(e)
+
+        assert "()" not in result, f"Aucune parenthèses vides attendues, obtenu : {result}"
+
+    def test_affichage_sans_variete(self):
+        """Scénario : format sans variété reste correct."""
+        from bot import _fmt_event
+
+        e = _make_event(162, "plantation", "tomate", variete=None, quantite=30.0)
+        result = _fmt_event(e)
+
+        assert "tomate" in result
+        assert "30.0plants" in result
+        assert "()" not in result

--- a/tests/test_resolve_parcelle.py
+++ b/tests/test_resolve_parcelle.py
@@ -1,0 +1,290 @@
+"""
+tests/test_resolve_parcelle.py — Tests unitaires pour resolve_parcelle
+-----------------------------------------------------------------------
+Vérifie que la résolution de nom de parcelle (LLM → FK BDD) fonctionne
+correctement dans tous les cas : exact, proche, introuvable, vide.
+Couvre aussi la validation dans le flux de correction (_corr_apply).
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from database.models import Parcelle, Evenement
+from utils.parcelles import resolve_parcelle
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_avec_parcelles(test_db):
+    """Insère Nord, Sud, Est dans la DB de test."""
+    test_db.add(Parcelle(nom="Nord", nom_normalise="nord", ordre=1, actif=True))
+    test_db.add(Parcelle(nom="Sud",  nom_normalise="sud",  ordre=2, actif=True))
+    test_db.add(Parcelle(nom="Est",  nom_normalise="est",  ordre=3, actif=True))
+    test_db.commit()
+    return test_db
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests de resolve_parcelle (utils/parcelles.py)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestResolveParcelle:
+    """Tests unitaires de la fonction resolve_parcelle."""
+
+    def test_resolution_exacte(self, db_avec_parcelles):
+        """Un nom exact (casse insensible) retourne la parcelle correspondante."""
+        result = resolve_parcelle(db_avec_parcelles, "Nord")
+        assert result is not None
+        assert result.nom == "Nord"
+
+    def test_resolution_exacte_majuscule(self, db_avec_parcelles):
+        """Nom tout en majuscules → résolution correcte."""
+        result = resolve_parcelle(db_avec_parcelles, "NORD")
+        assert result is not None
+        assert result.nom_normalise == "nord"
+
+    def test_resolution_proche_levenshtein(self, db_avec_parcelles):
+        """Nom avec 1 faute → résolution par correspondance approchée."""
+        result = resolve_parcelle(db_avec_parcelles, "Nrd")   # distance 1
+        assert result is not None
+        assert result.nom == "Nord"
+
+    def test_aucune_correspondance(self, db_avec_parcelles):
+        """Parcelle inconnue (aucune variante proche) → retourne None."""
+        # "Serre" est loin de nord/sud/est (distance > 2) → aucune résolution
+        result = resolve_parcelle(db_avec_parcelles, "Serre")
+        assert result is None
+
+    def test_nom_vide(self, db_avec_parcelles):
+        """Nom vide → retourne None sans erreur."""
+        assert resolve_parcelle(db_avec_parcelles, "") is None
+
+    def test_nom_none(self, db_avec_parcelles):
+        """None passé → retourne None sans erreur."""
+        assert resolve_parcelle(db_avec_parcelles, None) is None
+
+    def test_nom_espaces(self, db_avec_parcelles):
+        """Nom avec espaces seuls → retourne None sans erreur."""
+        assert resolve_parcelle(db_avec_parcelles, "   ") is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests d'intégration bot.py — _parse_and_save avec parcelle inconnue
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestParseAndSaveParcelleBloquee:
+    """Vérifie que _parse_and_save bloque si la parcelle est introuvable."""
+
+    @pytest.mark.asyncio
+    async def test_parcelle_inconnue_bloque_sauvegarde(self, test_db):
+        """Si la parcelle extraite par Groq n'existe pas, aucun événement n'est créé."""
+        update_mock = MagicMock()
+        update_mock.message.reply_text = AsyncMock()
+
+        parsed_item = {
+            "action": "plantation",
+            "culture": "courgette",
+            "quantite": 10,
+            "unite": "plants",
+            "parcelle": "Ouest",  # parcelle inexistante
+            "date": None,
+            "rang": None,
+            "duree_minutes": None,
+            "traitement": None,
+            "variete": None,
+            "commentaire": None,
+        }
+
+        with patch("bot.parse_commande", return_value=[parsed_item]), \
+             patch("bot._normalize_items", return_value=[parsed_item]), \
+             patch("bot.SessionLocal") as mock_session_local, \
+             patch("bot.resolve_parcelle", return_value=None):
+
+            mock_db = MagicMock()
+            mock_session_local.return_value = mock_db
+
+            from bot import _parse_and_save
+            await _parse_and_save(update_mock, "planter 10 courgettes parcelle Ouest")
+
+        # Vérifie que le message d'erreur a été envoyé
+        update_mock.message.reply_text.assert_called_once()
+        call_args = update_mock.message.reply_text.call_args
+        assert "Ouest" in call_args[0][0]
+        assert "n'existe pas" in call_args[0][0]
+
+        # Vérifie qu'aucun événement n'a été persisté
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_parcelle_connue_sauvegarde_avec_fk(self, test_db):
+        """Si la parcelle est résolue, l'événement est créé avec parcelle_id renseigné."""
+        parcelle_nord = Parcelle(id=1, nom="Nord", nom_normalise="nord", ordre=1, actif=True)
+
+        update_mock = MagicMock()
+        update_mock.message.reply_text = AsyncMock()
+
+        parsed_item = {
+            "action": "plantation",
+            "culture": "tomate",
+            "quantite": 5,
+            "unite": "plants",
+            "parcelle": "Nord",
+            "date": None,
+            "rang": None,
+            "duree_minutes": None,
+            "traitement": None,
+            "variete": None,
+            "commentaire": None,
+            "nb_graines_semees": None,
+            "nb_plants_godets": None,
+        }
+
+        evenement_mock = MagicMock()
+        evenement_mock.id = 42
+        evenement_mock.type_action = "plantation"
+        evenement_mock.culture = "tomate"
+        evenement_mock.quantite = 5.0
+        evenement_mock.unite = "plants"
+        evenement_mock.parcelle = "Nord"
+        evenement_mock.parcelle_id = 1
+        evenement_mock.rang = None
+        evenement_mock.date = None
+
+        with patch("bot.parse_commande", return_value=[parsed_item]), \
+             patch("bot._normalize_items", return_value=[parsed_item]), \
+             patch("bot.SessionLocal") as mock_session_local, \
+             patch("bot.resolve_parcelle", return_value=parcelle_nord), \
+             patch("bot.Evenement", return_value=evenement_mock), \
+             patch("bot._build_recap", return_value="✅ recap"), \
+             patch("bot.send_voice_reply", new_callable=AsyncMock), \
+             patch("bot.MENU_KEYBOARD", None), \
+             patch("bot.AFTER_RECORD_KEYBOARD", None):
+
+            mock_db = MagicMock()
+            mock_db.__enter__ = MagicMock(return_value=mock_db)
+            mock_db.__exit__ = MagicMock(return_value=False)
+            mock_session_local.return_value = mock_db
+
+            from bot import _parse_and_save
+            await _parse_and_save(update_mock, "planter 5 tomates parcelle Nord")
+
+        # L'événement doit avoir été ajouté
+        mock_db.add.assert_called_once_with(evenement_mock)
+        mock_db.commit.assert_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests flux de correction — _corr_apply avec parcelle inconnue
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCorrApplyParcelleValidation:
+    """Vérifie que _corr_apply bloque une correction vers une parcelle inconnue."""
+
+    @pytest.mark.asyncio
+    async def test_correction_parcelle_inconnue_bloque(self):
+        """Si la correction demande une parcelle inconnue, _corr_apply renvoie une erreur."""
+        update_mock = MagicMock()
+        update_mock.message.reply_text = AsyncMock()
+
+        ctx_mock = MagicMock()
+        ctx_mock.user_data = {
+            'mode': 'corr_apply',
+            'corr_event_id': 10,
+        }
+
+        event_mock = MagicMock()
+        event_mock.type_action = "plantation"
+        event_mock.culture = "poivron"
+        event_mock.variete = None
+        event_mock.quantite = 10.0
+        event_mock.unite = "plants"
+        event_mock.parcelle = None
+        event_mock.rang = None
+        event_mock.duree = None
+        event_mock.traitement = None
+        event_mock.commentaire = None
+        event_mock.date = None
+
+        # Simuler la réponse Groq → correction parcelle inconnue
+        groq_resp = MagicMock()
+        groq_resp.choices[0].message.content = '{"parcelle": "bretagne"}'
+
+        with patch("bot.SessionLocal") as mock_session_cls, \
+             patch("bot.resolve_parcelle", return_value=None) as mock_resolve, \
+             patch("groq.Groq") as mock_groq_cls, \
+             patch("bot.MENU_KEYBOARD", None):
+
+            mock_db = MagicMock()
+            mock_db.get.return_value = event_mock
+            mock_session_cls.return_value = mock_db
+
+            mock_groq_instance = MagicMock()
+            mock_groq_instance.chat.completions.create.return_value = groq_resp
+            mock_groq_cls.return_value = mock_groq_instance
+
+            from bot import _corr_apply
+            await _corr_apply(update_mock, ctx_mock, "plantation sur parcelle bretagne")
+
+        # resolve_parcelle doit avoir été appelée
+        mock_resolve.assert_called_once()
+        # Le mode NE doit PAS être passé en corr_confirm
+        assert ctx_mock.user_data.get('mode') != 'corr_confirm'
+
+    @pytest.mark.asyncio
+    async def test_correction_parcelle_connue_normalise_et_continue(self):
+        """Si la parcelle est résolue, son nom canonique remplace la valeur brute."""
+        update_mock = MagicMock()
+        update_mock.message.reply_text = AsyncMock()
+
+        ctx_mock = MagicMock()
+        ctx_mock.user_data = {
+            'mode': 'corr_apply',
+            'corr_event_id': 10,
+        }
+
+        event_mock = MagicMock()
+        event_mock.type_action = "plantation"
+        event_mock.culture = "poivron"
+        event_mock.variete = None
+        event_mock.quantite = 10.0
+        event_mock.unite = "plants"
+        event_mock.parcelle = None
+        event_mock.rang = None
+        event_mock.duree = None
+        event_mock.traitement = None
+        event_mock.commentaire = None
+        event_mock.date = None
+
+        parcelle_nord = MagicMock()
+        parcelle_nord.nom = "Nord"
+        parcelle_nord.id = 1
+
+        groq_resp = MagicMock()
+        groq_resp.choices[0].message.content = '{"parcelle": "NORD"}'
+
+        with patch("bot.SessionLocal") as mock_session_cls, \
+             patch("bot.resolve_parcelle", return_value=parcelle_nord), \
+             patch("groq.Groq") as mock_groq_cls, \
+             patch("bot.MENU_KEYBOARD", None):
+
+            mock_db = MagicMock()
+            mock_db.get.return_value = event_mock
+            mock_session_cls.return_value = mock_db
+
+            mock_groq_instance = MagicMock()
+            mock_groq_instance.chat.completions.create.return_value = groq_resp
+            mock_groq_cls.return_value = mock_groq_instance
+
+            from bot import _corr_apply
+            await _corr_apply(update_mock, ctx_mock, "plantation sur parcelle nord")
+
+        # Le mode doit être passé en corr_confirm
+        assert ctx_mock.user_data.get('mode') == 'corr_confirm'
+        # La correction doit contenir le nom canonique et l'id FK
+        pending = ctx_mock.user_data.get('corr_pending', {})
+        assert pending.get('parcelle') == "Nord"
+        assert pending.get('_parcelle_id') == 1
+

--- a/tests/test_us_aide_contextuelle_parcelle.py
+++ b/tests/test_us_aide_contextuelle_parcelle.py
@@ -1,0 +1,588 @@
+"""
+tests/test_us_aide_contextuelle_parcelle.py
+--------------------------------------------
+Tests US Aide contextuelle /help [commande]        (CA1–CA10)
+Tests US /parcelle sous-commandes modifier/lister  (CA1–CA10)
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bot import cmd_help, cmd_parcelle, _cmd_parcelles_lister
+from utils.parcelles import update_parcelle
+from database.models import Parcelle
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures communes
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_update():
+    """Update Telegram minimaliste avec reply_text mocké."""
+    upd = MagicMock()
+    upd.message.reply_text = AsyncMock()
+    return upd
+
+
+@pytest.fixture
+def mock_ctx():
+    """ContextTypes mocké avec args vide par défaut."""
+    ctx = MagicMock()
+    ctx.args = []
+    return ctx
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixture SQLite in-memory : parcelle de test
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def parcelle_nord(test_db):
+    """Crée une parcelle 'nord' dans la base SQLite de test."""
+    p = Parcelle(
+        nom="nord",
+        nom_normalise="nord",
+        exposition="est",
+        superficie_m2=10.0,
+        ordre=1,
+        actif=True,
+    )
+    test_db.add(p)
+    test_db.commit()
+    test_db.refresh(p)
+    return p
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# US 1 — Aide contextuelle /help [commande]
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestHelpCA1Parcelle:
+    @pytest.mark.asyncio
+    async def test_us_help_ca1_parcelle_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA1 — /help parcelle → message dédié parcelles (Parcelles, /plan, /parcelle ajouter)."""
+        # Arrange
+        mock_ctx.args = ["parcelle"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Parcelles" in texte
+        assert "/plan" in texte
+        assert "/parcelle ajouter" in texte
+
+
+class TestHelpCA2Semis:
+    @pytest.mark.asyncio
+    async def test_us_help_ca2_semis_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA2 — /help semis → message dédié semis (Semis, pépinière, pleine terre)."""
+        # Arrange
+        mock_ctx.args = ["semis"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Semis" in texte
+        assert "pépinière" in texte
+        assert "pleine terre" in texte
+
+
+class TestHelpCA3Godet:
+    @pytest.mark.asyncio
+    async def test_us_help_ca3_godet_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA3 — /help godet → message dédié godet."""
+        # Arrange
+        mock_ctx.args = ["godet"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "godet" in texte.lower()
+
+
+class TestHelpCA4Recolte:
+    @pytest.mark.asyncio
+    async def test_us_help_ca4_recolte_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA4 — /help recolte → message dédié récoltes."""
+        # Arrange
+        mock_ctx.args = ["recolte"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "écolte" in texte  # couvre "Récolte" et "récolte"
+
+
+class TestHelpCA5Stock:
+    @pytest.mark.asyncio
+    async def test_us_help_ca5_stock_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA5 — /help stock → message dédié stock."""
+        # Arrange
+        mock_ctx.args = ["stock"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Stock" in texte
+
+
+class TestHelpCA6Stats:
+    @pytest.mark.asyncio
+    async def test_us_help_ca6_stats_message_dedie(self, mock_update, mock_ctx) -> None:
+        """CA6 — /help stats → message dédié statistiques."""
+        # Arrange
+        mock_ctx.args = ["stats"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Statistiques" in texte
+
+
+class TestHelpCA7MotCleInconnu:
+    @pytest.mark.asyncio
+    async def test_us_help_ca7_mot_cle_inconnu_message_non_reconnu(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA7 — /help truc → message 'non reconnu' + liste des mots-clés."""
+        # Arrange
+        mock_ctx.args = ["truc"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "non reconnu" in texte or "truc" in texte
+        assert "parcelle" in texte  # liste des mots-clés contient "parcelle"
+
+    @pytest.mark.asyncio
+    async def test_us_help_ca7_mot_cle_inconnu_appel_unique(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA7 (edge) — un seul reply_text est envoyé pour un mot-clé inconnu."""
+        # Arrange
+        mock_ctx.args = ["motinconnu"]
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        assert mock_update.message.reply_text.call_count == 1
+
+
+class TestHelpCA8SansArgument:
+    @pytest.mark.asyncio
+    async def test_us_help_ca8_aide_generale_contient_sections(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA8 — /help sans argument → aide générale (AIDE, /stats, /historique)."""
+        # Arrange
+        mock_ctx.args = []
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "AIDE" in texte
+        assert "/stats" in texte
+        assert "/historique" in texte
+
+    @pytest.mark.asyncio
+    async def test_us_help_ca8_args_none_aide_generale(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA8 (edge) — ctx.args = None → aide générale (pas de crash)."""
+        # Arrange
+        mock_ctx.args = None
+        # Act
+        await cmd_help(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "AIDE" in texte
+
+
+class TestHelpCA9CasseInsensible:
+    @pytest.mark.asyncio
+    async def test_us_help_ca9_majuscule_meme_texte_que_minuscule(self) -> None:
+        """CA9 — /help Parcelle → même résultat que /help parcelle."""
+        # Arrange
+        upd_lower, upd_upper = MagicMock(), MagicMock()
+        upd_lower.message.reply_text = AsyncMock()
+        upd_upper.message.reply_text = AsyncMock()
+        ctx_lower, ctx_upper = MagicMock(), MagicMock()
+        ctx_lower.args = ["parcelle"]
+        ctx_upper.args = ["Parcelle"]
+        # Act
+        await cmd_help(upd_lower, ctx_lower)
+        await cmd_help(upd_upper, ctx_upper)
+        # Assert
+        assert upd_lower.message.reply_text.call_args[0][0] == \
+               upd_upper.message.reply_text.call_args[0][0]
+
+
+class TestHelpCA10AccentInsensible:
+    @pytest.mark.asyncio
+    async def test_us_help_ca10_accent_recolte_meme_texte(self) -> None:
+        """CA10 — /help récolte (accent) → même résultat que /help recolte."""
+        # Arrange
+        upd_sans, upd_accent = MagicMock(), MagicMock()
+        upd_sans.message.reply_text = AsyncMock()
+        upd_accent.message.reply_text = AsyncMock()
+        ctx_sans, ctx_accent = MagicMock(), MagicMock()
+        ctx_sans.args = ["recolte"]
+        ctx_accent.args = ["récolte"]
+        # Act
+        await cmd_help(upd_sans, ctx_sans)
+        await cmd_help(upd_accent, ctx_accent)
+        # Assert
+        assert upd_sans.message.reply_text.call_args[0][0] == \
+               upd_accent.message.reply_text.call_args[0][0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# US 2a — update_parcelle (fonction directe, SQLite in-memory)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestUpdateParcelleCA4Exposition:
+    def test_us_parcelle_ca4_modifier_exposition(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA4 — update_parcelle met à jour l'exposition."""
+        # Act
+        parc, modifs = update_parcelle(test_db, "nord", exposition="sud")
+        # Assert
+        assert parc.exposition == "sud"
+        assert any("Exposition" in m for m in modifs)
+
+
+class TestUpdateParcelleCA5Superficie:
+    def test_us_parcelle_ca5_modifier_superficie(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA5 — update_parcelle met à jour la superficie."""
+        # Act
+        parc, modifs = update_parcelle(test_db, "nord", superficie="8.5")
+        # Assert
+        assert parc.superficie_m2 == pytest.approx(8.5)
+        assert any("Superficie" in m for m in modifs)
+
+
+class TestUpdateParcelleCA6DeuxChamps:
+    def test_us_parcelle_ca6_modifier_exposition_et_superficie(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA6 — update_parcelle met à jour exposition ET superficie ensemble."""
+        # Act
+        parc, modifs = update_parcelle(
+            test_db, "nord", exposition="ouest", superficie="12.0"
+        )
+        # Assert
+        assert parc.exposition == "ouest"
+        assert parc.superficie_m2 == pytest.approx(12.0)
+        assert len(modifs) == 2
+
+    def test_us_parcelle_ca6_deux_champs_liste_modifs_distincte(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA6 (edge) — chaque champ modifié génère une entrée distincte dans modifs."""
+        # Act
+        _, modifs = update_parcelle(
+            test_db, "nord", exposition="nord", superficie="5.0"
+        )
+        # Assert
+        assert any("Exposition" in m for m in modifs)
+        assert any("Superficie" in m for m in modifs)
+
+
+class TestUpdateParcelleCA7Inexistante:
+    def test_us_parcelle_ca7_parcelle_inexistante_lever_lookup_error(
+        self, test_db
+    ) -> None:
+        """CA7 — update_parcelle lève LookupError si la parcelle est inexistante."""
+        # Act / Assert
+        with pytest.raises(LookupError):
+            update_parcelle(test_db, "fantome", exposition="sud")
+
+
+class TestUpdateParcelleCA8ParamInconnu:
+    def test_us_parcelle_ca8_parametre_inconnu_lever_value_error(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA8 — update_parcelle lève ValueError pour un paramètre inconnu."""
+        # Act / Assert
+        with pytest.raises(ValueError, match="inconnu"):
+            update_parcelle(test_db, "nord", couleur="verte")
+
+    def test_us_parcelle_ca8_message_erreur_cite_parametre(
+        self, test_db, parcelle_nord
+    ) -> None:
+        """CA8 (edge) — le message d'erreur cite le nom du paramètre inconnu."""
+        # Act / Assert
+        with pytest.raises(ValueError) as exc_info:
+            update_parcelle(test_db, "nord", couleur="verte")
+        assert "couleur" in str(exc_info.value)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# US 2b — cmd_parcelle (via bot, SessionLocal mocké)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCmdParcelleListerCA1:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca1_lister_affiche_parcelles(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA1 — /parcelle lister → affiche les parcelles enregistrées en BDD."""
+        # Arrange
+        p = MagicMock(spec=Parcelle)
+        p.nom = "nord"
+        p.exposition = "sud"
+        p.superficie_m2 = 10.0
+        mock_ctx.args = ["lister"]
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.get_all_parcelles", return_value=[p]):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "NORD" in texte
+
+
+class TestCmdParcelleListerCA2BddVide:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca2_lister_bdd_vide_aucune_parcelle(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA2 — /parcelle lister sur BDD vide → message 'Aucune parcelle'."""
+        # Arrange
+        mock_ctx.args = ["lister"]
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.get_all_parcelles", return_value=[]):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Aucune parcelle" in texte
+
+
+class TestCmdParcellesAliasCA3:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca3_alias_parcelles_meme_comportement(
+        self, mock_update
+    ) -> None:
+        """CA3 — /parcelles → même comportement que /parcelle lister (BDD vide)."""
+        # Arrange
+        ctx = MagicMock()
+        ctx.args = []
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.get_all_parcelles", return_value=[]):
+            await _cmd_parcelles_lister(mock_update, ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Aucune parcelle" in texte
+
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca3_alias_parcelles_avec_donnees(
+        self, mock_update
+    ) -> None:
+        """CA3 (edge) — /parcelles avec parcelles en base → mêmes noms que /parcelle lister."""
+        # Arrange
+        p = MagicMock(spec=Parcelle)
+        p.nom = "sud"
+        p.exposition = None
+        p.superficie_m2 = None
+        ctx = MagicMock()
+        ctx.args = []
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.get_all_parcelles", return_value=[p]):
+            await _cmd_parcelles_lister(mock_update, ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "SUD" in texte
+
+
+class TestCmdParcelleModifierCA4Exposition:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca4_modifier_exposition_succes(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA4 — /parcelle modifier nord exposition=sud → réponse succès."""
+        # Arrange
+        mock_ctx.args = ["modifier", "nord", "exposition=sud"]
+        p = MagicMock(spec=Parcelle)
+        p.nom = "nord"
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.update_parcelle", return_value=(p, ["Exposition : sud"])):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "✅" in texte
+        assert "Exposition" in texte
+
+
+class TestCmdParcelleModifierCA5Superficie:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca5_modifier_superficie_succes(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA5 — /parcelle modifier nord superficie=8.5 → réponse succès."""
+        # Arrange
+        mock_ctx.args = ["modifier", "nord", "superficie=8.5"]
+        p = MagicMock(spec=Parcelle)
+        p.nom = "nord"
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.update_parcelle", return_value=(p, ["Superficie : 8.5 m²"])):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "✅" in texte
+        assert "Superficie" in texte
+
+
+class TestCmdParcelleModifierCA6DeuxChamps:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca6_modifier_deux_champs_affiche_les_deux(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA6 — /parcelle modifier nord exposition=sud superficie=8.5 → deux lignes de modif."""
+        # Arrange
+        mock_ctx.args = ["modifier", "nord", "exposition=sud", "superficie=8.5"]
+        p = MagicMock(spec=Parcelle)
+        p.nom = "nord"
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.update_parcelle", return_value=(p, ["Exposition : sud", "Superficie : 8.5 m²"])):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "Exposition" in texte
+        assert "Superficie" in texte
+
+
+class TestCmdParcelleModifierCA7Inexistante:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca7_parcelle_introuvable_message_erreur(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA7 — /parcelle modifier inexistante exposition=sud → message 'introuvable'."""
+        # Arrange
+        mock_ctx.args = ["modifier", "inexistante", "exposition=sud"]
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.update_parcelle", side_effect=LookupError("inexistante")), \
+             patch("bot.get_all_parcelles", return_value=[]):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "introuvable" in texte.lower()
+
+
+class TestCmdParcelleModifierCA8ParamInconnu:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca8_parametre_inconnu_message_erreur(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA8 — /parcelle modifier nord couleur=verte → message 'Paramètre inconnu'."""
+        # Arrange
+        mock_ctx.args = ["modifier", "nord", "couleur=verte"]
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        err = ValueError(
+            "Paramètre(s) inconnu(s) : couleur. Acceptés : exposition, superficie, ordre"
+        )
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.update_parcelle", side_effect=err):
+            await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "❌" in texte
+        assert "inconnu" in texte.lower()
+
+
+class TestCmdParcelleModifierCA9SansArgSuffisant:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca9_modifier_sans_nom_message_usage(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA9 — /parcelle modifier sans nom ni valeur → message d'usage."""
+        # Arrange
+        mock_ctx.args = ["modifier"]
+        # Act  (pas de SessionLocal nécessaire : return avant tout appel DB)
+        await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "/parcelle modifier" in texte
+
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca9_modifier_avec_nom_seulement_message_usage(
+        self, mock_update, mock_ctx
+    ) -> None:
+        """CA9 (edge) — /parcelle modifier nord (sans clé=valeur) → message d'usage."""
+        # Arrange
+        mock_ctx.args = ["modifier", "nord"]
+        # Act
+        await cmd_parcelle(mock_update, mock_ctx)
+        # Assert
+        texte = mock_update.message.reply_text.call_args[0][0]
+        assert "/parcelle modifier" in texte
+
+
+class TestCmdParcelleAjouterCA10Pending:
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca10_ajouter_stocke_exposition_et_superficie(
+        self, mock_update
+    ) -> None:
+        """CA10 — /parcelle ajouter nord sud 12.5 → pending contient exposition=sud et superficie=12.5."""
+        # Arrange
+        ctx = MagicMock()
+        ctx.args = ["ajouter", "nord", "sud", "12.5"]
+        ctx.user_data = {}
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.find_doublon", return_value=(None, None)), \
+             patch("bot.get_all_parcelles", return_value=[]):
+            await cmd_parcelle(mock_update, ctx)
+        # Assert
+        pending = ctx.user_data.get("parcelle_pending", {})
+        assert pending.get("exposition") == "sud"
+        assert pending.get("superficie_m2") == pytest.approx(12.5)
+
+    @pytest.mark.asyncio
+    async def test_us_parcelle_ca10_ajouter_mode_parcelle_confirm(
+        self, mock_update
+    ) -> None:
+        """CA10 (edge) — /parcelle ajouter nord sud 12.5 → user_data['mode'] == 'parcelle_confirm'."""
+        # Arrange
+        ctx = MagicMock()
+        ctx.args = ["ajouter", "nord", "sud", "12.5"]
+        ctx.user_data = {}
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+        # Act
+        with patch("bot.SessionLocal", return_value=mock_db), \
+             patch("bot.find_doublon", return_value=(None, None)), \
+             patch("bot.get_all_parcelles", return_value=[]):
+            await cmd_parcelle(mock_update, ctx)
+        # Assert
+        assert ctx.user_data.get("mode") == "parcelle_confirm"

--- a/tests/test_us_plan_occupation_parcelles.py
+++ b/tests/test_us_plan_occupation_parcelles.py
@@ -1,0 +1,507 @@
+"""
+tests/test_us_plan_occupation_parcelles.py
+-------------------------------------------
+Tests US_Plan_occupation_parcelles (issue GitHub #18)
+
+Couvre :
+- CA11 : normalize_parcelle_name (casse, accents, tirets, espaces)
+- CA12 : levenshtein_distance (cas nominaux)
+- CA10/CA12 : find_doublon (exact, proche, aucun)
+- CA1-CA7 : calcul_occupation_parcelles (cultures actives, sans parcelle, âge J+, alerte)
+- CA3 : seuils alerte végétatif ≥ 45j, reproducteur ≥ 90j
+- cmd_plan sans arg (mock)
+- cmd_plan avec parcelle inconnue
+- cmd_parcelle ajouter : création, doublon exact, variante proche
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from utils.parcelles import (
+    normalize_parcelle_name,
+    levenshtein_distance,
+    find_doublon,
+    create_parcelle,
+    get_all_parcelles,
+    calcul_occupation_parcelles,
+)
+from database.models import Evenement, Parcelle, CultureConfig
+from bot import _alerte_recolte, SEUIL_ALERTE
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_with_parcelles(test_db):
+    """BD de test avec quelques parcelles pré-insérées."""
+    db = test_db
+    db.add(Parcelle(nom="Nord", nom_normalise="nord", ordre=1, actif=True))
+    db.add(Parcelle(nom="Sud", nom_normalise="sud", ordre=2, actif=True))
+    db.add(Parcelle(nom="Est", nom_normalise="est", ordre=3, actif=True))
+    db.commit()
+    return db
+
+
+@pytest.fixture
+def db_with_cultures(test_db):
+    """BD avec plantations actives pour tester calcul_occupation_parcelles."""
+    db = test_db
+
+    # CultureConfig
+    db.add(CultureConfig(nom="tomate", type_organe_recolte="reproducteur"))
+    db.add(CultureConfig(nom="salade", type_organe_recolte="végétatif"))
+    db.add(CultureConfig(nom="basilic", type_organe_recolte="végétatif"))
+    db.commit()
+
+    today = datetime.now()
+    # Tomate dans parcelle NORD plantée il y a 27 jours
+    db.add(Evenement(
+        type_action="plantation",
+        culture="tomate",
+        variete="Cœur de Bœuf",
+        quantite=3.0,
+        rang=1,
+        unite="plants",
+        parcelle="NORD",
+        date=today - timedelta(days=27),
+    ))
+    # Salade dans parcelle NORD plantée il y a 50 jours (> seuil 45j végétatif)
+    db.add(Evenement(
+        type_action="plantation",
+        culture="salade",
+        variete="Batavia",
+        quantite=8.0,
+        rang=1,
+        unite="plants",
+        parcelle="NORD",
+        date=today - timedelta(days=50),
+    ))
+    # Basilic sans parcelle plantée il y a 8 jours
+    db.add(Evenement(
+        type_action="plantation",
+        culture="basilic",
+        variete=None,
+        quantite=20.0,
+        rang=1,
+        unite="plants",
+        parcelle=None,
+        date=today - timedelta(days=8),
+    ))
+    db.commit()
+    return db
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CA11 — normalize_parcelle_name
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNormalizeParcelleName:
+    def test_lowercase(self) -> None:
+        """CA11 — Mise en minuscules."""
+        assert normalize_parcelle_name("NORD") == "nord"
+
+    def test_strip_spaces(self) -> None:
+        """CA11 — Strip des espaces en début/fin."""
+        assert normalize_parcelle_name("  nord  ") == "nord"
+
+    def test_remove_accents(self) -> None:
+        """CA11 — Suppression des accents."""
+        assert normalize_parcelle_name("côté") == "cote"
+
+    def test_remove_hyphens(self) -> None:
+        """CA11 — Suppression des tirets."""
+        assert normalize_parcelle_name("nord-est") == "nordest"
+
+    def test_remove_internal_spaces(self) -> None:
+        """CA11 — Suppression des espaces internes."""
+        assert normalize_parcelle_name("côté est") == "cotéest".replace("é", "e")
+
+    def test_mixed(self) -> None:
+        """CA11 — Combinaison : casse + accents + tirets."""
+        assert normalize_parcelle_name("  Côté-Est  ") == "coteest"
+
+    def test_simple_word(self) -> None:
+        """CA11 — Mot simple sans transformation."""
+        assert normalize_parcelle_name("serre") == "serre"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CA12 — levenshtein_distance
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestLevenshteinDistance:
+    def test_identical_strings(self) -> None:
+        """Distance entre deux chaînes identiques = 0."""
+        assert levenshtein_distance("nord", "nord") == 0
+
+    def test_empty_strings(self) -> None:
+        """Distance entre deux chaînes vides = 0."""
+        assert levenshtein_distance("", "") == 0
+
+    def test_one_empty(self) -> None:
+        """Distance d'une chaîne vide à 'abc' = len(abc)."""
+        assert levenshtein_distance("", "abc") == 3
+        assert levenshtein_distance("abc", "") == 3
+
+    def test_single_substitution(self) -> None:
+        """1 substitution → distance = 1."""
+        assert levenshtein_distance("nord", "nard") == 1
+
+    def test_single_insertion(self) -> None:
+        """1 insertion → distance = 1."""
+        assert levenshtein_distance("nor", "nord") == 1
+
+    def test_single_deletion(self) -> None:
+        """1 suppression → distance = 1."""
+        assert levenshtein_distance("nords", "nord") == 1
+
+    def test_distance_2(self) -> None:
+        """Distance de 2 → seuil de variante proche (CA12)."""
+        assert levenshtein_distance("nrd", "nord") == 1
+        assert levenshtein_distance("sud", "sude") == 1
+        # 'nor' → 'est' = 3 (au-delà du seuil)
+        assert levenshtein_distance("nor", "est") == 3
+
+    def test_completely_different(self) -> None:
+        """Chaînes complètement différentes → grande distance."""
+        assert levenshtein_distance("abc", "xyz") == 3
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CA10, CA12 — find_doublon
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestFindDoublon:
+    def test_exact_match(self, db_with_parcelles) -> None:
+        """CA10 — Doublon exact trouvé."""
+        exact, proche = find_doublon(db_with_parcelles, "nord")
+        assert exact is not None
+        assert exact.nom_normalise == "nord"
+        assert proche is None
+
+    def test_no_match(self, db_with_parcelles) -> None:
+        """Aucun doublon → (None, None)."""
+        exact, proche = find_doublon(db_with_parcelles, "zzzparcelle")
+        assert exact is None
+        assert proche is None
+
+    def test_proche_match(self, db_with_parcelles) -> None:
+        """CA12 — Variante proche (Levenshtein ≤ 2) détectée."""
+        # "nrd" est à distance 1 de "nord"
+        exact, proche = find_doublon(db_with_parcelles, "nrd")
+        assert exact is None
+        assert proche is not None
+        assert proche.nom_normalise == "nord"
+
+    def test_exact_takes_priority(self, db_with_parcelles) -> None:
+        """L'exact match prend priorité, proche non retourné si exact trouvé."""
+        exact, proche = find_doublon(db_with_parcelles, "sud")
+        assert exact is not None
+        assert exact.nom_normalise == "sud"
+        assert proche is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CA1-CA7 — calcul_occupation_parcelles
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCalculOccupationParcelles:
+    def test_cultures_actives_groupees(self, db_with_cultures) -> None:
+        """CA1 — Les cultures avec stock > 0 sont incluses."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        # NORD doit avoir salade et tomate
+        nord = result.get("NORD", [])
+        cultures_nord = {c["culture"] for c in nord}
+        assert "tomate" in cultures_nord
+        assert "salade" in cultures_nord
+
+    def test_cultures_sans_parcelle(self, db_with_cultures) -> None:
+        """CA7 — Cultures sans parcelle groupées sous clé None."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        sans_parcelle = result.get(None, [])
+        assert len(sans_parcelle) > 0
+        cultures = {c["culture"] for c in sans_parcelle}
+        assert "basilic" in cultures
+
+    def test_age_jours_calcule(self, db_with_cultures) -> None:
+        """CA2 — L'âge J+ est calculé depuis la date de plantation."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        nord = result.get("NORD", [])
+        tomate = next((c for c in nord if c["culture"] == "tomate"), None)
+        assert tomate is not None
+        assert 26 <= tomate["age_jours"] <= 28  # tolérance ±1j
+
+    def test_age_jours_salade(self, db_with_cultures) -> None:
+        """CA2 — Âge de la salade (50 jours)."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        nord = result.get("NORD", [])
+        salade = next((c for c in nord if c["culture"] == "salade"), None)
+        assert salade is not None
+        assert 49 <= salade["age_jours"] <= 51
+
+    def test_empty_when_no_plantations(self, test_db) -> None:
+        """Retourne dict vide si aucune plantation."""
+        result = calcul_occupation_parcelles(test_db)
+        assert result == {}
+
+    def test_nb_plants(self, db_with_cultures) -> None:
+        """CA1 — Le nb_plants est correctement calculé."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        nord = result.get("NORD", [])
+        tomate = next((c for c in nord if c["culture"] == "tomate"), None)
+        assert tomate is not None
+        assert tomate["nb_plants"] == 3.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CA3 — Seuils alerte
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestAlerteRecolte:
+    def test_vegetatif_sous_seuil(self) -> None:
+        """CA3 — Végétatif < 45j → pas d'alerte."""
+        assert _alerte_recolte("végétatif", 44) is False
+
+    def test_vegetatif_au_seuil(self) -> None:
+        """CA3 — Végétatif = 45j → alerte."""
+        assert _alerte_recolte("végétatif", 45) is True
+
+    def test_vegetatif_depasse_seuil(self) -> None:
+        """CA3 — Végétatif > 45j → alerte."""
+        assert _alerte_recolte("végétatif", 50) is True
+
+    def test_reproducteur_sous_seuil(self) -> None:
+        """CA3 — Reproducteur < 90j → pas d'alerte."""
+        assert _alerte_recolte("reproducteur", 89) is False
+
+    def test_reproducteur_au_seuil(self) -> None:
+        """CA3 — Reproducteur = 90j → alerte."""
+        assert _alerte_recolte("reproducteur", 90) is True
+
+    def test_sans_type_organe(self) -> None:
+        """CA3 — Type organe None → pas d'alerte."""
+        assert _alerte_recolte(None, 200) is False
+
+    def test_seuils_values(self) -> None:
+        """CA3 — Vérifier les valeurs de SEUIL_ALERTE."""
+        assert SEUIL_ALERTE["végétatif"] == 45
+        assert SEUIL_ALERTE["reproducteur"] == 90
+
+    def test_alerte_salade_50j(self, db_with_cultures) -> None:
+        """CA3 — Salade plantée à J+50 déclenche alerte (végétatif ≥ 45j)."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        nord = result.get("NORD", [])
+        salade = next((c for c in nord if c["culture"] == "salade"), None)
+        assert salade is not None
+        assert _alerte_recolte(salade["type_organe"], salade["age_jours"]) is True
+
+    def test_pas_alerte_tomate_27j(self, db_with_cultures) -> None:
+        """CA3 — Tomate plantée à J+27 ne déclenche pas d'alerte (reproducteur < 90j)."""
+        result = calcul_occupation_parcelles(db_with_cultures)
+        nord = result.get("NORD", [])
+        tomate = next((c for c in nord if c["culture"] == "tomate"), None)
+        assert tomate is not None
+        assert _alerte_recolte(tomate["type_organe"], tomate["age_jours"]) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# cmd_plan — mocks Telegram
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _make_update_ctx(args=None):
+    """Construit un (update, ctx) mockés pour les tests de commandes."""
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.reply_text = AsyncMock()
+    ctx = MagicMock()
+    ctx.args = args or []
+    ctx.user_data = {}
+    return update, ctx
+
+
+class TestCmdPlan:
+    @pytest.mark.asyncio
+    async def test_cmd_plan_global_no_cultures(self) -> None:
+        """cmd_plan sans arg et sans cultures → aucune erreur, message envoyé."""
+        update, ctx = _make_update_ctx(args=[])
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.calcul_occupation_parcelles", return_value={}),
+            patch("bot.get_all_parcelles", return_value=[]),
+            patch("bot.send_voice_reply", new_callable=AsyncMock),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_plan
+            await cmd_plan(update, ctx)
+
+        update.message.reply_text.assert_called_once()
+        texte_envoye = update.message.reply_text.call_args[0][0]
+        assert "Plan d'occupation" in texte_envoye
+
+    @pytest.mark.asyncio
+    async def test_cmd_plan_parcelle_inconnue(self) -> None:
+        """CA5 — cmd_plan avec parcelle inconnue → message 'Aucune culture active'."""
+        update, ctx = _make_update_ctx(args=["zzz"])
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.calcul_occupation_parcelles", return_value={}),
+            patch("bot.get_all_parcelles", return_value=[]),
+            patch("bot.send_voice_reply", new_callable=AsyncMock),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_plan
+            await cmd_plan(update, ctx)
+
+        texte_envoye = update.message.reply_text.call_args[0][0]
+        assert "Aucune culture active" in texte_envoye
+
+    @pytest.mark.asyncio
+    async def test_cmd_plan_parcelle_avec_cultures(self) -> None:
+        """CA5 — cmd_plan avec parcelle connue affiche les cultures."""
+        update, ctx = _make_update_ctx(args=["nord"])
+        cultures = [{
+            "culture": "tomate",
+            "variete": "Cœur de Bœuf",
+            "nb_plants": 3.0,
+            "unite": "plants",
+            "type_organe": "reproducteur",
+            "date_plantation": datetime.now() - timedelta(days=27),
+            "age_jours": 27,
+        }]
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.calcul_occupation_parcelles", return_value={"NORD": cultures}),
+            patch("bot.get_all_parcelles", return_value=[]),
+            patch("bot.send_voice_reply", new_callable=AsyncMock),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_plan
+            await cmd_plan(update, ctx)
+
+        texte_envoye = update.message.reply_text.call_args[0][0]
+        assert "NORD" in texte_envoye
+        assert "tomate" in texte_envoye
+        assert "J+27" in texte_envoye
+
+    @pytest.mark.asyncio
+    async def test_cmd_plan_hint_pied_message(self) -> None:
+        """CA6 — Le hint est présent en pied de message vue globale."""
+        update, ctx = _make_update_ctx(args=[])
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.calcul_occupation_parcelles", return_value={}),
+            patch("bot.get_all_parcelles", return_value=[]),
+            patch("bot.send_voice_reply", new_callable=AsyncMock),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_plan
+            await cmd_plan(update, ctx)
+
+        texte_envoye = update.message.reply_text.call_args[0][0]
+        assert "/plan [nom parcelle]" in texte_envoye
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# cmd_parcelle — mocks Telegram
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCmdParcelle:
+    @pytest.mark.asyncio
+    async def test_parcelle_ajouter_sans_nom(self) -> None:
+        """CA13 — /parcelle ajouter sans nom → message d'erreur."""
+        update, ctx = _make_update_ctx(args=["ajouter"])
+        with patch("bot.SessionLocal") as mock_sl:
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_parcelle
+            await cmd_parcelle(update, ctx)
+
+        texte = update.message.reply_text.call_args[0][0]
+        assert "Précisez" in texte
+
+    @pytest.mark.asyncio
+    async def test_parcelle_doublon_exact(self) -> None:
+        """CA10 — Doublon exact → refus avec message ❌."""
+        update, ctx = _make_update_ctx(args=["ajouter", "nord"])
+        parcelle_existante = Parcelle(nom="Nord", nom_normalise="nord", ordre=1, actif=True)
+
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.normalize_parcelle_name", return_value="nord"),
+            patch("bot.find_doublon", return_value=(parcelle_existante, None)),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_parcelle
+            await cmd_parcelle(update, ctx)
+
+        texte = update.message.reply_text.call_args[0][0]
+        assert "❌" in texte
+        assert "NORD" in texte.upper()
+
+    @pytest.mark.asyncio
+    async def test_parcelle_variante_proche(self) -> None:
+        """CA12 — Variante proche → demande confirmation."""
+        update, ctx = _make_update_ctx(args=["ajouter", "nrd"])
+        parcelle_proche = Parcelle(nom="Nord", nom_normalise="nord", ordre=1, actif=True)
+
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.normalize_parcelle_name", return_value="nrd"),
+            patch("bot.find_doublon", return_value=(None, parcelle_proche)),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_parcelle
+            await cmd_parcelle(update, ctx)
+
+        texte = update.message.reply_text.call_args[0][0]
+        assert "⚠️" in texte
+        assert "similaire" in texte.lower()
+        assert ctx.user_data.get('mode') == 'parcelle_confirm'
+
+    @pytest.mark.asyncio
+    async def test_parcelle_ajouter_nouveau(self) -> None:
+        """CA13 — Nouvelle parcelle sans doublon → affiche récap + demande confirmation."""
+        update, ctx = _make_update_ctx(args=["ajouter", "ouest"])
+
+        with (
+            patch("bot.SessionLocal") as mock_sl,
+            patch("bot.normalize_parcelle_name", return_value="ouest"),
+            patch("bot.find_doublon", return_value=(None, None)),
+            patch("bot.get_all_parcelles", return_value=[]),
+        ):
+            mock_db = MagicMock()
+            mock_sl.return_value = mock_db
+
+            from bot import cmd_parcelle
+            await cmd_parcelle(update, ctx)
+
+        texte = update.message.reply_text.call_args[0][0]
+        assert "OUEST" in texte.upper()
+        assert ctx.user_data.get('mode') == 'parcelle_confirm'
+        assert ctx.user_data.get('parcelle_pending', {}).get('nom') == 'ouest'
+
+    @pytest.mark.asyncio
+    async def test_parcelle_usage_sans_args(self) -> None:
+        """Aucun argument → message d'usage affiché."""
+        update, ctx = _make_update_ctx(args=[])
+        from bot import cmd_parcelle
+        await cmd_parcelle(update, ctx)
+        texte = update.message.reply_text.call_args[0][0]
+        assert "Usage" in texte

--- a/utils/parcelles.py
+++ b/utils/parcelles.py
@@ -1,0 +1,378 @@
+"""
+utils/parcelles.py — Gestion des parcelles du potager
+-------------------------------------------------------
+[US_Plan_occupation_parcelles]
+
+Fonctions :
+- normalize_parcelle_name  : forme canonique (CA11)
+- levenshtein_distance     : distance pure Python (CA12)
+- find_doublon             : détection doublons exact / proche (CA10, CA12)
+- create_parcelle          : création avec vérification doublon (CA13)
+- get_all_parcelles        : liste triée par ordre (CA4)
+- calcul_occupation_parcelles : structure d'occupation par parcelle (CA1-CA7)
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+from unidecode import unidecode
+
+from database.models import Evenement, Parcelle
+from utils.stock import calcul_stock_cultures
+
+log = logging.getLogger("potager")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA11] Normalisation du nom de parcelle
+# ──────────────────────────────────────────────────────────────────────────────
+
+def normalize_parcelle_name(nom: str) -> str:
+    """
+    [CA11] Normalise un nom de parcelle : strip + lower + suppression accents
+    + suppression tirets et espaces.
+
+    Exemples :
+      "Nord"    → "nord"
+      "Côté Est" → "cotéest" → "coteest"
+      "nord-est"→ "nordest"
+    """
+    s = nom.strip().lower()
+    s = unidecode(s)               # suppression accents
+    s = re.sub(r"[\s\-]+", "", s)  # suppression tirets et espaces
+    return s
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA12] Distance de Levenshtein (pure Python)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def levenshtein_distance(a: str, b: str) -> int:
+    """
+    [CA12] Calcule la distance de Levenshtein entre deux chaînes.
+    Implémentation pure Python — pas de dépendance externe.
+    """
+    if a == b:
+        return 0
+    len_a, len_b = len(a), len(b)
+    if len_a == 0:
+        return len_b
+    if len_b == 0:
+        return len_a
+
+    # Optimisation : n'utiliser que deux lignes
+    prev = list(range(len_b + 1))
+    curr = [0] * (len_b + 1)
+
+    for i in range(1, len_a + 1):
+        curr[0] = i
+        for j in range(1, len_b + 1):
+            cost = 0 if a[i - 1] == b[j - 1] else 1
+            curr[j] = min(
+                prev[j] + 1,        # suppression
+                curr[j - 1] + 1,    # insertion
+                prev[j - 1] + cost, # substitution
+            )
+        prev, curr = curr, [0] * (len_b + 1)
+
+    return prev[len_b]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA10, CA12] Détection doublons
+# ──────────────────────────────────────────────────────────────────────────────
+
+def find_doublon(
+    db: Session, nom_normalise: str
+) -> Tuple[Optional[Parcelle], Optional[Parcelle]]:
+    """
+    [CA10, CA12] Recherche un doublon exact ou une variante proche (Levenshtein ≤ 2).
+
+    Retourne (exact_match, proche_match) :
+    - exact_match  : Parcelle dont nom_normalise == nom_normalise fourni
+    - proche_match : Parcelle dont la distance Levenshtein ≤ 2 (si pas d'exact)
+    """
+    # Doublon exact
+    exact = (
+        db.query(Parcelle)
+        .filter(Parcelle.nom_normalise == nom_normalise)
+        .first()
+    )
+    if exact:
+        return exact, None
+
+    # Variante proche (Levenshtein ≤ 2)
+    toutes = db.query(Parcelle).filter(Parcelle.actif.is_(True)).all()
+    for p in toutes:
+        if levenshtein_distance(nom_normalise, p.nom_normalise) <= 2:
+            return None, p
+
+    return None, None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA13] Création d'une parcelle
+# ──────────────────────────────────────────────────────────────────────────────
+
+def resolve_parcelle(db: Session, nom: str) -> Optional[Parcelle]:
+    """
+    Résout un nom de parcelle libre (issu du LLM) vers l'objet Parcelle en base.
+
+    Stratégie :
+    1. Correspondance exacte sur nom_normalise → retourne immédiatement
+    2. Correspondance proche (Levenshtein ≤ 2) → retourne la variante (log warning)
+    3. Aucune correspondance → retourne None
+
+    Args:
+        db  : session SQLAlchemy
+        nom : nom brut extrait par le LLM (ex : "Ouest", "NORD", "cote est")
+
+    Returns:
+        Parcelle correspondante ou None
+    """
+    if not nom or not nom.strip():
+        return None
+    nom_normalise = normalize_parcelle_name(nom)
+    exact, proche = find_doublon(db, nom_normalise)
+    if exact:
+        return exact
+    if proche:
+        log.warning(
+            f"[resolve_parcelle] Correspondance approchée : "
+            f"{nom!r} → {proche.nom!r} (distance Levenshtein ≤ 2)"
+        )
+        return proche
+    return None
+
+
+def create_parcelle(
+    db: Session,
+    nom: str,
+    exposition: Optional[str] = None,
+    superficie_m2: Optional[float] = None,
+) -> Parcelle:
+    """
+    [CA13] Crée une nouvelle parcelle avec nom_normalise calculé.
+    ordre = nombre de parcelles existantes + 1.
+    Lève ValueError si un doublon exact existe déjà.
+    """
+    nom_normalise = normalize_parcelle_name(nom)
+    exact, _ = find_doublon(db, nom_normalise)
+    if exact:
+        raise ValueError(f"La parcelle « {exact.nom.upper()} » existe déjà.")
+
+    nb_existantes = db.query(Parcelle).count()
+    parcelle = Parcelle(
+        nom=nom,
+        nom_normalise=nom_normalise,
+        exposition=exposition,
+        superficie_m2=superficie_m2,
+        ordre=nb_existantes + 1,
+        actif=True,
+    )
+    db.add(parcelle)
+    db.commit()
+    db.refresh(parcelle)
+    log.info(f"[US_Plan_occupation_parcelles] Parcelle créée : {nom!r} (ordre={parcelle.ordre})")
+    return parcelle
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles] Mise à jour des métadonnées d'une parcelle
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CHAMPS_MODIFIER = {"exposition", "superficie", "ordre"}
+
+
+def update_parcelle(
+    db: Session, nom: str, **kwargs
+) -> Tuple[Parcelle, List[str]]:
+    """
+    Met à jour les métadonnées d'une parcelle existante.
+
+    Paramètres acceptés via kwargs : exposition, superficie (float m²), ordre (int).
+    Lève ValueError  si un paramètre est inconnu ou mal typé.
+    Lève LookupError si la parcelle est introuvable.
+
+    Retourne (parcelle_mise_a_jour, liste_des_modifs_texte).
+    """
+    inconnus = set(kwargs) - _CHAMPS_MODIFIER
+    if inconnus:
+        raise ValueError(
+            f"Paramètre(s) inconnu(s) : {', '.join(sorted(inconnus))}. "
+            f"Acceptés : exposition, superficie, ordre"
+        )
+
+    nom_normalise = normalize_parcelle_name(nom)
+    parcelle = (
+        db.query(Parcelle)
+        .filter(Parcelle.nom_normalise == nom_normalise)
+        .first()
+    )
+    if parcelle is None:
+        raise LookupError(nom)
+
+    modifs: List[str] = []
+    if "exposition" in kwargs:
+        parcelle.exposition = kwargs["exposition"]
+        modifs.append(f"Exposition : {kwargs['exposition']}")
+    if "superficie" in kwargs:
+        try:
+            val = float(kwargs["superficie"])
+        except (ValueError, TypeError):
+            raise ValueError("superficie doit être un nombre décimal (ex : 8.5)")
+        parcelle.superficie_m2 = val
+        modifs.append(f"Superficie : {val} m²")
+    if "ordre" in kwargs:
+        try:
+            val_ord = int(kwargs["ordre"])
+        except (ValueError, TypeError):
+            raise ValueError("ordre doit être un entier (ex : 1)")
+        parcelle.ordre = val_ord
+        modifs.append(f"Ordre : {val_ord}")
+
+    db.commit()
+    db.refresh(parcelle)
+    log.info(
+        f"[US_Plan_occupation_parcelles] Parcelle mise à jour : {parcelle.nom!r} — {modifs}"
+    )
+    return parcelle, modifs
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA4] Liste des parcelles
+# ──────────────────────────────────────────────────────────────────────────────
+
+def get_all_parcelles(db: Session) -> List[Parcelle]:
+    """
+    [CA4] Retourne toutes les parcelles actives triées par ordre croissant.
+    """
+    return (
+        db.query(Parcelle)
+        .filter(Parcelle.actif.is_(True))
+        .order_by(Parcelle.ordre)
+        .all()
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# [US_Plan_occupation_parcelles / CA1-CA7] Structure d'occupation
+# ──────────────────────────────────────────────────────────────────────────────
+
+def calcul_occupation_parcelles(db: Session) -> Dict[Optional[str], list]:
+    """
+    [CA1-CA7] Calcule la structure d'occupation du potager par parcelle.
+
+    Retourne un dict :
+    {
+        "NORD": [
+            {
+                "culture": "tomate",
+                "variete": "Cœur de Bœuf",
+                "nb_plants": 3.0,
+                "unite": "plants",
+                "type_organe": "reproducteur",
+                "date_plantation": datetime,
+                "age_jours": 27,
+            },
+            ...
+        ],
+        None: [...]   # [CA7] cultures sans parcelle renseignée
+    }
+
+    Seules les cultures avec stock > 0 sont incluses.
+    Groupées par (culture, variete, parcelle) depuis les événements de plantation.
+    """
+    # ── 1. Cultures actives (stock > 0) ──────────────────────────────────────
+    stocks = calcul_stock_cultures(db)
+    cultures_actives = {c for c, s in stocks.items() if s.stock_plants > 0}
+
+    if not cultures_actives:
+        return {}
+
+    # ── 2. Événements de plantation pour cultures actives ────────────────────
+    rows = (
+        db.query(
+            Evenement.culture,
+            Evenement.variete,
+            Evenement.parcelle,
+            Evenement.quantite,
+            Evenement.rang,
+            Evenement.unite,
+            Evenement.date,
+        )
+        .filter(Evenement.type_action == "plantation")
+        .filter(Evenement.culture.in_(list(cultures_actives)))
+        .order_by(Evenement.date)
+        .all()
+    )
+
+    # ── 3. Agrégation par (culture, variete, parcelle) ───────────────────────
+    # Clé : (culture, variete_norm, parcelle)
+    groupes: Dict[tuple, dict] = {}
+
+    for culture, variete, parcelle, quantite, rang, unite, date_evt in rows:
+        variete_norm = variete or ""
+        key = (culture, variete_norm, parcelle)
+        total = (quantite or 0) * (rang or 1)
+
+        if key not in groupes:
+            groupes[key] = {
+                "culture": culture,
+                "variete": variete_norm,
+                "nb_plants": 0.0,
+                "unite": unite or "plants",
+                "date_premiere": date_evt,
+            }
+
+        groupes[key]["nb_plants"] += total
+
+        # Garder la date la plus ancienne
+        if date_evt and (
+            groupes[key]["date_premiere"] is None
+            or date_evt < groupes[key]["date_premiere"]
+        ):
+            groupes[key]["date_premiere"] = date_evt
+
+    # ── 4. Construction du résultat final ─────────────────────────────────────
+    today = datetime.now().date()
+    result: Dict[Optional[str], list] = {}
+
+    for (culture, variete, parcelle), data in groupes.items():
+        stock = stocks.get(culture)
+        # [CA1] Ne garder que les cultures avec stock actif
+        if not stock or stock.stock_plants <= 0:
+            continue
+
+        date_plantation = data["date_premiere"]
+        if date_plantation and hasattr(date_plantation, "date"):
+            age_jours = (today - date_plantation.date()).days
+        elif date_plantation:
+            age_jours = (today - date_plantation).days
+        else:
+            age_jours = 0
+
+        entree = {
+            "culture": culture,
+            "variete": variete,
+            "nb_plants": data["nb_plants"],
+            "unite": data["unite"],
+            "type_organe": stock.type_organe,           # [CA3] pour seuil alerte
+            "date_plantation": date_plantation,
+            "age_jours": max(0, age_jours),
+        }
+
+        if parcelle not in result:
+            result[parcelle] = []
+        result[parcelle].append(entree)
+
+    log.info(
+        f"[US_Plan_occupation_parcelles] calcul_occupation_parcelles : "
+        f"{sum(len(v) for v in result.values())} cultures actives, "
+        f"{len(result)} parcelles"
+    )
+    return result


### PR DESCRIPTION
This pull request introduces two major new features: contextual help by command and a comprehensive "plan d'occupation" for garden parcels. It also adds the ability to modify parcel metadata, list all parcels, and improves the `/parcelle ajouter` command. Technical enhancements include new utility functions for parcel management, improved help message structuring, and stricter validation for parcel operations. The changes are documented in detail, with acceptance criteria, user stories, and Gherkin scenarios to guide implementation and testing.

---

**Contextual Help System:**

* Adds contextual help by keyword via `/help [mot-clé]` (e.g., `/help parcelle`, `/help semis`, etc.), with dedicated, static help messages per domain, examples, and fallback to a list of valid keywords if an unknown one is provided. The general `/help` remains unchanged. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-c6ec70c21ffee155e3316d709f9957c6af943a5c5b9629eec8852dce469feedfR1-R244)
* Static help content and keyword parsing are case- and accent-insensitive, with all expected message templates and behavior detailed in the user story.

**Plan d’Occupation Parcelles Feature:**

* Introduces `/plan` for a global view of the garden by parcel, showing active crops, their age, and harvest alerts; `/plan [nom]` for a detailed view of a specific parcel; and recognizes equivalent voice commands. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-9044a3eb59ed052d84fd2aa27efffaff52a79c037fb8f2b3e0c7bfa7b01c135bR1-R357)
* Cultures without a parcel are grouped under "Non localisé", and free parcels are indicated. The system handles duplicate and similar parcel names with normalization and Levenshtein distance checks, requiring confirmation for near-duplicates.
* Adds SQLAlchemy model `Parcelle` and migration for the new table, with normalization logic and CRUD operations in `utils/parcelles.py`. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-9044a3eb59ed052d84fd2aa27efffaff52a79c037fb8f2b3e0c7bfa7b01c135bR1-R357)

**Parcel Management Enhancements:**

* Adds `/parcelle modifier [nom] clé=valeur...` to update parcel metadata (exposition, superficie, ordre), with validation and error handling for unknown fields or missing parcels. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-9044a3eb59ed052d84fd2aa27efffaff52a79c037fb8f2b3e0c7bfa7b01c135bR1-R357)
* Implements `/parcelle lister` and alias `/parcelles` to list all parcels, and enriches `/parcelle ajouter` to accept `exposition` and `superficie` as positional parameters. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-9044a3eb59ed052d84fd2aa27efffaff52a79c037fb8f2b3e0c7bfa7b01c135bR1-R357)

**Technical Improvements:**

* Adds static help message constants to `bot.py`, utility functions for parcel normalization and management, and passes new parameters in the parcel creation confirmation handler.
* Documents all changes in `PATCH_NOTES.md` and provides comprehensive acceptance criteria and Gherkin scenarios for all new features. [[1]](diffhunk://#diff-da38f5cba5a449aa231aaabad3fc88e3bda32d80afcce3701697fa3fb35c4807R2-R32) [[2]](diffhunk://#diff-c6ec70c21ffee155e3316d709f9957c6af943a5c5b9629eec8852dce469feedfR1-R244) [[3]](diffhunk://#diff-9044a3eb59ed052d84fd2aa27efffaff52a79c037fb8f2b3e0c7bfa7b01c135bR1-R357)- Implemented tests for US_Plan_occupation_parcelles covering various functionalities including normalization, levenshtein distance, duplicate detection, and occupation calculation.
- Added utility functions in parcelles.py for normalizing parcelle names, calculating levenshtein distance, finding duplicates, creating and updating parcelles, and calculating occupation structure.