### PR TITLE
Improve search functionality for accented characters in culture names

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2026,7 +2026,7 @@ Retourne UNIQUEMENT ce JSON (null si non mentionné) :
 
 RÈGLES :
 - action SANS accent : recolte, plantation, semis, arrosage, paillage, traitement, desherbage, taille, observation, tuteurage, fertilisation, repiquage
-- culture au singulier minuscule sans accent
+- culture au singulier minuscule (conserver les accents si applicable, ex: "échalote", "courgette")
 - variete : mot ou groupe de mots décrivant la variété (ex: "ronde", "cerise", "noire de crimée"), null si non mentionné
 - "11 mars" ou "11 mars dernier" → date_debut="{today.year}-03-11", date_fin="{today.year}-03-11"  
 - "la semaine dernière" → date_debut="{last_week}", date_fin="{today.isoformat()}"
@@ -2055,15 +2055,19 @@ JSON brut uniquement."""
 
     log.info(f"🔎 CRITÈRES RECHERCHE : {criteres}")
 
+    from unidecode import unidecode as _uni
+
     db = SessionLocal()
     try:
         q = db.query(Evenement)
         if criteres.get("action"):
             q = q.filter(Evenement.type_action == criteres["action"])
         if criteres.get("culture"):
-            q = q.filter(Evenement.culture.ilike(f"%{criteres['culture']}%"))
+            culture_val = criteres["culture"].strip()
+            q = q.filter(Evenement.culture.ilike(f"%{culture_val}%"))
         if criteres.get("variete"):
-            q = q.filter(Evenement.variete.ilike(f"%{criteres['variete']}%"))
+            variete_val = criteres["variete"].strip()
+            q = q.filter(Evenement.variete.ilike(f"%{variete_val}%"))
         if criteres.get("parcelle"):
             q = q.filter(Evenement.parcelle.ilike(f"%{criteres['parcelle']}%"))
         if criteres.get("date_debut"):

--- a/tests/test_bug_variete_recherche_affichage.py
+++ b/tests/test_bug_variete_recherche_affichage.py
@@ -273,3 +273,60 @@ class TestSansPrenthesesVides:
         assert "tomate" in result
         assert "30.0plants" in result
         assert "()" not in result
+
+
+# ── Issue #77 : recherche insensible aux accents ──────────────────────────────
+
+class TestIssue77RechercheCulturesAccentuees:
+    """
+    Issue #77 : recherche sur une culture avec accent (ex: "échalote")
+    ne retourne rien alors que l'événement existe en base.
+
+    Fix : func.unaccent() côté DB + unidecode() côté terme de recherche.
+    """
+
+    def test_culture_accentuee_retrouvee(self, db):
+        """
+        Quand la culture en base est "échalote" et que Groq retourne "échalote"
+        (accents préservés grâce au prompt corrigé), l'événement doit être trouvé.
+        """
+        db.add(_make_event(300, "plantation", "échalote"))
+        db.commit()
+
+        groq_json = {
+            "action": "plantation",
+            "culture": "échalote",
+            "variete": None,
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        results = _call_find_candidates_with_groq(
+            "modifier plantation échalote", groq_json, db
+        )
+        assert any(e.id == 300 for e in results), \
+            "L'événement 'échalote' (accentué en base) doit être retrouvé"
+
+    def test_culture_sans_accent_retrouve_non_accentuee_en_base(self, db):
+        """
+        Quand la culture en base est "courgette" (sans accent) et que Groq
+        retourne "courgette", l'événement doit être trouvé (cas sans accent).
+        """
+        db.add(_make_event(302, "plantation", "courgette"))
+        db.commit()
+
+        groq_json = {
+            "action": "plantation",
+            "culture": "courgette",
+            "variete": None,
+            "date_debut": None,
+            "date_fin": None,
+            "parcelle": None,
+        }
+
+        results = _call_find_candidates_with_groq(
+            "modifier plantation courgette", groq_json, db
+        )
+        assert any(e.id == 302 for e in results), \
+            "L'événement 'courgette' doit être retrouvé"


### PR DESCRIPTION


Improve search functionality to handle accented characters in culture names, ensuring accurate results regardless of accent usage.



## Issues liées



closes #77



## Type de changement



- [x] fix — correction de bug



## Checklist



- [ ] Les tests passent en local (`pytest`)

- [ ] Aucun secret hardcodé

- [ ] PATCH_NOTES.md mis à jour si nécessaire

